### PR TITLE
Usgs/pdl#10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+
 language: java
 
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,2 @@
 language: java
 install: true
-script: ant test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,11 @@ language: java
 jdk:
   - oraclejdk8
   - oraclejdk7
-  - openjdk6
 
 install:
   - ssh-keygen -f ~/.ssh/id_rsa -t rsa -N '' -b 4096
   - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
   - chmod 700 ~/.ssh/authorized_keys
-  - ssh -vvv localhost 'pwd && ls'
 
 addons:
   ssh_known_hosts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,6 @@
 language: java
-
-java:
-  - '1.8.0'
-  - '1.7.0'
-
-  install:
-    - ant deps
-
-  script:
-    - ant test
-
-  addons:
-    ssh_known_hosts:
-      - 127.0.0.1
+install: ant deps
+script: ant test
+addons:
+  ssh_known_hosts:
+    - 127.0.0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: java
+install: true
 script: ant test
-addons:
-  ssh_known_hosts:
-    - 127.0.0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 install:
-  - ssh-keygen -t rsa -N '' -b 4096
+  - ssh-keygen -f key.rsa -t rsa -N '' -b 4096
 
 addons:
   ssh_known_hosts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: java
+
+java:
+  - '1.8.0'
+  - '1.7.0'
+
+  install:
+    - ant deps
+
+  script:
+    - ant test
+
+  addons:
+    ssh_known_hosts:
+      - 127.0.0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ jdk:
   - openjdk6
 
 install:
-  - ssh-keygen -f ~/.ssh/key.rsa -t rsa -N '' -b 4096
-  - cat ~/.ssh/key.rsa.pub >> ~/.ssh/authorized_keys
+  - ssh-keygen -f ~/.ssh/id_rsa -t rsa -N '' -b 4096
+  - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
   - chmod 700 ~/.ssh/authorized_keys
   - ssh -vvv localhost 'pwd && ls'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
-install: ant deps
 script: ant test
 addons:
   ssh_known_hosts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 install:
-  - ssh-keygen -t -rsa -N '' -b 4096
+  - ssh-keygen -t rsa -N '' -b 4096
 
 addons:
   ssh_known_hosts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: java
+
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk6
+
 install:
   - ssh-keygen -f ~/.ssh/key.rsa -t rsa -N '' -b 4096
   - cat ~/.ssh/key.rsa.pub >> ~/.ssh/authorized_keys
   - chmod 700 ~/.ssh/authorized_keys
-  - ssh localhost 'pwd && ls'
+  - ssh -vvv localhost 'pwd && ls'
 
 addons:
   ssh_known_hosts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: java
 install:
-  - ssh-keygen -f key.rsa -t rsa -N '' -b 4096
+  - ssh-keygen -f ~/.ssh/key.rsa -t rsa -N '' -b 4096
+  - cat ~/.ssh/key.rsa.pub >> ~/.ssh/authorized_keys
+  - chmod 700 ~/.ssh/authorized_keys
+  - ssh localhost 'pwd && ls'
 
 addons:
   ssh_known_hosts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,8 @@
 language: java
-install: true
+install:
+  - ssh-keygen -t -rsa -N '' -b 4096
+
+addons:
+  ssh_known_hosts:
+  - 127.0.0.1
+  - localhost


### PR DESCRIPTION
fixes usgs/pdl#10

- Set up travis
- This test java versions 1.7 and 1.8
- Version 1.6 fails with the following error  'cannot access com.google.publicalerts.cap.TrustStrategy'