### PR TITLE
Source source code not unique

### DIFF
--- a/etc/examples/client/bin/ExampleListener.py
+++ b/etc/examples/client/bin/ExampleListener.py
@@ -82,7 +82,7 @@ class Product(object):
 			product = Product()
 			product.parseArguments(args)
 			return product
-		except Exception, e:
+		except Exception:
 			#invalid product
 			return None
 	

--- a/etc/test_products/ci37645983/ci-origin-ci37645983-1494867948050.xml
+++ b/etc/test_products/ci37645983/ci-origin-ci37645983-1494867948050.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<product xmlns="http://earthquake.usgs.gov/distribution/product" id="urn:usgs-product:ci:origin:ci37645983:1494867948050" updateTime="2017-05-15T17:05:48.050Z" status="UPDATE" trackerURL="http://ehppdl1.cr.usgs.gov/tracker/">
+	<property name="azimuthal-gap" value="179"/>
+	<property name="depth" value="4.41"/>
+	<property name="depth-type" value="from location"/>
+	<property name="error-ellipse-azimuth" value="219"/>
+	<property name="error-ellipse-intermediate" value="3000"/>
+	<property name="error-ellipse-major" value="19416"/>
+	<property name="error-ellipse-minor" value="1248"/>
+	<property name="error-ellipse-plunge" value="87"/>
+	<property name="error-ellipse-rotation" value="339"/>
+	<property name="evaluation-status" value="preliminary"/>
+	<property name="event-type" value="earthquake"/>
+	<property name="eventParametersPublicID" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645983"/>
+	<property name="eventsource" value="ci"/>
+	<property name="eventsourcecode" value="37645983"/>
+	<property name="eventtime" value="2017-05-15T17:03:45.490Z"/>
+	<property name="horizontal-error" value="1.25"/>
+	<property name="latitude" value="33.6910019"/>
+	<property name="longitude" value="-117.9104996"/>
+	<property name="magnitude" value="1.82"/>
+	<property name="magnitude-azimuthal-gap" value="140"/>
+	<property name="magnitude-error" value="0.654"/>
+	<property name="magnitude-num-stations-used" value="4"/>
+	<property name="magnitude-source" value="CI"/>
+	<property name="magnitude-type" value="ml"/>
+	<property name="minimum-distance" value="0.3560"/>
+	<property name="num-phases-used" value="28"/>
+	<property name="num-stations-used" value="28"/>
+	<property name="origin-source" value="CI"/>
+	<property name="quakeml-magnitude-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?magnitudeid=7092879"/>
+	<property name="quakeml-origin-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?originid=4773287"/>
+	<property name="quakeml-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645983"/>
+	<property name="review-status" value="automatic"/>
+	<property name="standard-error" value="0.41"/>
+	<property name="title" value="3km N of Costa Mesa, CA"/>
+	<property name="version" value="2"/>
+	<property name="vertical-error" value="8.08"/>
+	<signature>MCwCFCr1B7XBNuKOtkz3eO8F1mL5z46bAhQEKKl9D3CqVViYPFdQ/4C2fhastw==</signature>
+</product>

--- a/etc/test_products/ci37645983/ci-origin-ci37645983-1494868047790.xml
+++ b/etc/test_products/ci37645983/ci-origin-ci37645983-1494868047790.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<product xmlns="http://earthquake.usgs.gov/distribution/product" id="urn:usgs-product:ci:origin:ci37645983:1494868047790" updateTime="2017-05-15T17:07:27.790Z" status="UPDATE" trackerURL="http://prod01-pdl01.cr.usgs.gov/tracker">
+	<property name="azimuthal-gap" value="143"/>
+	<property name="depth" value="2.61"/>
+	<property name="depth-type" value="operator assigned"/>
+	<property name="evaluation-status" value="preliminary"/>
+	<property name="event-type" value="earthquake"/>
+	<property name="eventParametersPublicID" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645983"/>
+	<property name="eventsource" value="ci"/>
+	<property name="eventsourcecode" value="37645983"/>
+	<property name="eventtime" value="2017-05-15T17:03:45.540Z"/>
+	<property name="horizontal-error" value="1"/>
+	<property name="latitude" value="33.681"/>
+	<property name="longitude" value="-117.8908333"/>
+	<property name="magnitude" value="1.69"/>
+	<property name="magnitude-azimuthal-gap" value="167.9"/>
+	<property name="magnitude-error" value="0.357"/>
+	<property name="magnitude-num-stations-used" value="8"/>
+	<property name="magnitude-source" value="CI"/>
+	<property name="magnitude-type" value="ml"/>
+	<property name="minimum-distance" value="0.4012"/>
+	<property name="num-phases-used" value="15"/>
+	<property name="num-stations-used" value="15"/>
+	<property name="origin-source" value="CI"/>
+	<property name="quakeml-magnitude-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?magnitudeid=107962916"/>
+	<property name="quakeml-origin-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?originid=104902404"/>
+	<property name="quakeml-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645983"/>
+	<property name="review-status" value="automatic"/>
+	<property name="standard-error" value="0.34"/>
+	<property name="version" value="3"/>
+	<property name="vertical-error" value="31.61"/>
+	<signature>MC0CFQDB91ZM/GE0jySbicineTl2OUdX5QIURI+7FxQrS8c78DHyIHTDWT+DNws=</signature>
+</product>

--- a/etc/test_products/ci37645983/ci-origin-ci37645983-1494874177010.xml
+++ b/etc/test_products/ci37645983/ci-origin-ci37645983-1494874177010.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<product xmlns="http://earthquake.usgs.gov/distribution/product" id="urn:usgs-product:ci:origin:ci37645983:1494874177010" updateTime="2017-05-15T18:49:37.010Z" status="DELETE" trackerURL="http://prod01-pdl01.cr.usgs.gov/tracker">
+	<property name="eventParametersPublicID" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645983"/>
+	<property name="eventsource" value="ci"/>
+	<property name="eventsourcecode" value="37645983"/>
+	<property name="quakeml-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645983"/>
+	<property name="version" value="4"/>
+	<signature>MCwCFHLOUmyy3AVn+oL4RVmzFBnTdBRMAhQPyFMBNgkdBbZvrWeNSbviepyL6A==</signature>
+</product>

--- a/etc/test_products/ci37645983/ci-origin-ci37645983-1494874177050.xml
+++ b/etc/test_products/ci37645983/ci-origin-ci37645983-1494874177050.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<product xmlns="http://earthquake.usgs.gov/distribution/product" id="urn:usgs-product:ci:origin:ci37645983:1494874177050" updateTime="2017-05-15T18:49:37.050Z" status="DELETE" trackerURL="http://prod01-pdl01.cr.usgs.gov/tracker">
+	<property name="eventParametersPublicID" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645983"/>
+	<property name="eventsource" value="ci"/>
+	<property name="eventsourcecode" value="37645983"/>
+	<property name="quakeml-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645983"/>
+	<property name="version" value="4"/>
+	<signature>MCwCFF2jSnqTQIzS8DUQ26MysxuhdUDFAhRX4/Bh1vOvNsf1RcfD1l6Gi5OwPQ==</signature>
+</product>

--- a/etc/test_products/ci37645983/ci-origin-ci37645983-1494874177480.xml
+++ b/etc/test_products/ci37645983/ci-origin-ci37645983-1494874177480.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<product xmlns="http://earthquake.usgs.gov/distribution/product" id="urn:usgs-product:ci:origin:ci37645983:1494874177480" updateTime="2017-05-15T18:49:37.480Z" status="DELETE" trackerURL="http://prod01-pdl01.cr.usgs.gov/tracker">
+	<property name="eventParametersPublicID" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645983"/>
+	<property name="eventsource" value="ci"/>
+	<property name="eventsourcecode" value="37645983"/>
+	<property name="quakeml-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645983"/>
+	<property name="version" value="4"/>
+	<signature>MC0CFQC2KLz+qCQB3LPrbZ+Wk4V3qCgfDwIUB6OlSpfai7LJtwtRR1lIPis/5pQ=</signature>
+</product>

--- a/etc/test_products/ci37645983/ci-origin-ci37645983-1494874177530.xml
+++ b/etc/test_products/ci37645983/ci-origin-ci37645983-1494874177530.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<product xmlns="http://earthquake.usgs.gov/distribution/product" id="urn:usgs-product:ci:origin:ci37645983:1494874177530" updateTime="2017-05-15T18:49:37.530Z" status="DELETE" trackerURL="http://prod01-pdl01.cr.usgs.gov/tracker">
+	<property name="eventParametersPublicID" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645983"/>
+	<property name="eventsource" value="ci"/>
+	<property name="eventsourcecode" value="37645983"/>
+	<property name="quakeml-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645983"/>
+	<property name="version" value="4"/>
+	<signature>MCwCFH049SkOwu/5SYIhVdxXa7JjBxVUAhR1NAJBpDYoRpdxQNT3dfpO537unA==</signature>
+</product>

--- a/etc/test_products/ci37645983/ci-origin-ci37645983-1494874177890.xml
+++ b/etc/test_products/ci37645983/ci-origin-ci37645983-1494874177890.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<product xmlns="http://earthquake.usgs.gov/distribution/product" id="urn:usgs-product:ci:origin:ci37645983:1494874177890" updateTime="2017-05-15T18:49:37.890Z" status="DELETE" trackerURL="http://ehppdl1.cr.usgs.gov/tracker/">
+	<property name="eventParametersPublicID" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645983"/>
+	<property name="eventsource" value="ci"/>
+	<property name="eventsourcecode" value="37645983"/>
+	<property name="quakeml-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645983"/>
+	<property name="version" value="2"/>
+	<signature>MC0CFQDLz6EoeAsA92SJwZlihD+/HjMJQgIUbvjrrWmGFRKl2jT1YojSUAssAQs=</signature>
+</product>

--- a/etc/test_products/ci37645983/ci-origin-ci37645983-1494892985010.xml
+++ b/etc/test_products/ci37645983/ci-origin-ci37645983-1494892985010.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<product xmlns="http://earthquake.usgs.gov/distribution/product" id="urn:usgs-product:ci:origin:ci37645983:1494892985010" updateTime="2017-05-16T00:03:05.010Z" status="UPDATE" trackerURL="http://prod01-pdl01.cr.usgs.gov/tracker">
+	<property name="azimuthal-gap" value="71"/>
+	<property name="depth" value="-0.66"/>
+	<property name="depth-type" value="operator assigned"/>
+	<property name="error-ellipse-azimuth" value="0"/>
+	<property name="error-ellipse-intermediate" value="1080"/>
+	<property name="error-ellipse-major" value="75864"/>
+	<property name="error-ellipse-minor" value="744"/>
+	<property name="error-ellipse-plunge" value="90"/>
+	<property name="error-ellipse-rotation" value="57"/>
+	<property name="evaluation-status" value="final"/>
+	<property name="event-type" value="quarry blast"/>
+	<property name="eventParametersPublicID" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645983"/>
+	<property name="eventsource" value="ci"/>
+	<property name="eventsourcecode" value="37645983"/>
+	<property name="eventtime" value="2017-05-15T17:03:51.060Z"/>
+	<property name="horizontal-error" value="0.45"/>
+	<property name="latitude" value="33.8228333"/>
+	<property name="longitude" value="-117.4835"/>
+	<property name="magnitude" value="1.32"/>
+	<property name="magnitude-azimuthal-gap" value="90.6"/>
+	<property name="magnitude-error" value="0.198"/>
+	<property name="magnitude-num-stations-used" value="31"/>
+	<property name="magnitude-source" value="CI"/>
+	<property name="magnitude-type" value="ml"/>
+	<property name="minimum-distance" value="0.03250"/>
+	<property name="num-phases-used" value="35"/>
+	<property name="num-stations-used" value="34"/>
+	<property name="origin-source" value="CI"/>
+	<property name="quakeml-magnitude-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?magnitudeid=107963236"/>
+	<property name="quakeml-origin-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?originid=104902724"/>
+	<property name="quakeml-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645983"/>
+	<property name="review-status" value="reviewed"/>
+	<property name="standard-error" value="0.21"/>
+	<property name="version" value="6"/>
+	<property name="vertical-error" value="31.61"/>
+	<signature>MC0CFEpMtD3Qn16zuZuwhKKgnDP3mVq3AhUAv0xjr0Jj5GOiwo8p5JUwGpFHJTI=</signature>
+</product>

--- a/etc/test_products/ci37645983/ci-origin-ci37645991-1494868066040.xml
+++ b/etc/test_products/ci37645983/ci-origin-ci37645991-1494868066040.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<product xmlns="http://earthquake.usgs.gov/distribution/product" id="urn:usgs-product:ci:origin:ci37645991:1494868066040" updateTime="2017-05-15T17:07:46.040Z" status="UPDATE" trackerURL="http://prod01-pdl01.cr.usgs.gov/tracker">
+	<property name="azimuthal-gap" value="148"/>
+	<property name="depth" value="17.73"/>
+	<property name="depth-type" value="from location"/>
+	<property name="evaluation-status" value="preliminary"/>
+	<property name="event-type" value="earthquake"/>
+	<property name="eventParametersPublicID" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645991"/>
+	<property name="eventsource" value="ci"/>
+	<property name="eventsourcecode" value="37645991"/>
+	<property name="eventtime" value="2017-05-15T17:03:51.920Z"/>
+	<property name="horizontal-error" value="0.84"/>
+	<property name="latitude" value="33.6006667"/>
+	<property name="longitude" value="-117.654"/>
+	<property name="magnitude" value="1.75"/>
+	<property name="magnitude-azimuthal-gap" value="183.6"/>
+	<property name="magnitude-error" value="0.335"/>
+	<property name="magnitude-num-stations-used" value="35"/>
+	<property name="magnitude-source" value="CI"/>
+	<property name="magnitude-type" value="ml"/>
+	<property name="minimum-distance" value="0.08222"/>
+	<property name="num-phases-used" value="9"/>
+	<property name="num-stations-used" value="9"/>
+	<property name="origin-source" value="CI"/>
+	<property name="quakeml-magnitude-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?magnitudeid=107962924"/>
+	<property name="quakeml-origin-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?originid=104902412"/>
+	<property name="quakeml-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645991"/>
+	<property name="review-status" value="automatic"/>
+	<property name="standard-error" value="0.19"/>
+	<property name="version" value="3"/>
+	<property name="vertical-error" value="1.2"/>
+	<signature>MC0CFH5RyrDm1QjJfMb9eQBqgAF3HAOfAhUAxN7R68ktfkcIYnL+3aFnqLriJWU=</signature>
+</product>

--- a/etc/test_products/ci37645983/ci-origin-ci37645991-1494874160300.xml
+++ b/etc/test_products/ci37645983/ci-origin-ci37645991-1494874160300.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<product xmlns="http://earthquake.usgs.gov/distribution/product" id="urn:usgs-product:ci:origin:ci37645991:1494874160300" updateTime="2017-05-15T18:49:20.300Z" status="DELETE" trackerURL="http://prod01-pdl01.cr.usgs.gov/tracker">
+	<property name="eventParametersPublicID" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645991"/>
+	<property name="eventsource" value="ci"/>
+	<property name="eventsourcecode" value="37645991"/>
+	<property name="quakeml-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645991"/>
+	<property name="version" value="4"/>
+	<signature>MC0CFQCgmld+GdE2wt+LOE0G5icniwdbNAIUNVt2h2epQH3s7lw5mLJuR/4jgdQ=</signature>
+</product>

--- a/etc/test_products/ci37645983/ci-origin-ci37645991-1494874160350.xml
+++ b/etc/test_products/ci37645983/ci-origin-ci37645991-1494874160350.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<product xmlns="http://earthquake.usgs.gov/distribution/product" id="urn:usgs-product:ci:origin:ci37645991:1494874160350" updateTime="2017-05-15T18:49:20.350Z" status="DELETE" trackerURL="http://prod01-pdl01.cr.usgs.gov/tracker">
+	<property name="eventParametersPublicID" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645991"/>
+	<property name="eventsource" value="ci"/>
+	<property name="eventsourcecode" value="37645991"/>
+	<property name="quakeml-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645991"/>
+	<property name="version" value="4"/>
+	<signature>MCwCFD0JDjI0h4h7PvuB4QIOocVvuTZkAhRFFwETRiO3sC3eNt9LkeoPvAydtg==</signature>
+</product>

--- a/etc/test_products/ci37645983/ci-origin-ci37645991-1494874160800.xml
+++ b/etc/test_products/ci37645983/ci-origin-ci37645991-1494874160800.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<product xmlns="http://earthquake.usgs.gov/distribution/product" id="urn:usgs-product:ci:origin:ci37645991:1494874160800" updateTime="2017-05-15T18:49:20.800Z" status="DELETE" trackerURL="http://prod01-pdl01.cr.usgs.gov/tracker">
+	<property name="eventParametersPublicID" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645991"/>
+	<property name="eventsource" value="ci"/>
+	<property name="eventsourcecode" value="37645991"/>
+	<property name="quakeml-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645991"/>
+	<property name="version" value="4"/>
+	<signature>MCwCFB2Rl9KedzKig8bFkWr7WV+8i41aAhQ7jHMr57h02fdL11psG82KL5DPww==</signature>
+</product>

--- a/etc/test_products/ci37645983/ci-origin-ci37645991-1494874160830.xml
+++ b/etc/test_products/ci37645983/ci-origin-ci37645991-1494874160830.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<product xmlns="http://earthquake.usgs.gov/distribution/product" id="urn:usgs-product:ci:origin:ci37645991:1494874160830" updateTime="2017-05-15T18:49:20.830Z" status="DELETE" trackerURL="http://prod01-pdl01.cr.usgs.gov/tracker">
+	<property name="eventParametersPublicID" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645991"/>
+	<property name="eventsource" value="ci"/>
+	<property name="eventsourcecode" value="37645991"/>
+	<property name="quakeml-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645991"/>
+	<property name="version" value="4"/>
+	<signature>MC0CFQCAcLhaUjFq/yyAC0b3B+riZsqrBAIULmSDm+hw4iVJlOjOQGI9iEXyyEg=</signature>
+</product>

--- a/etc/test_products/ci37645983/ci-origin-ci37645991-1494893051170.xml
+++ b/etc/test_products/ci37645983/ci-origin-ci37645991-1494893051170.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<product xmlns="http://earthquake.usgs.gov/distribution/product" id="urn:usgs-product:ci:origin:ci37645991:1494893051170" updateTime="2017-05-16T00:04:11.170Z" status="DELETE" trackerURL="http://prod01-pdl01.cr.usgs.gov/tracker">
+	<property name="eventParametersPublicID" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645991"/>
+	<property name="eventsource" value="ci"/>
+	<property name="eventsourcecode" value="37645991"/>
+	<property name="quakeml-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645991"/>
+	<property name="version" value="4"/>
+	<signature>MC4CFQCXKGnFf7W1a3Icwpo9+q7jC98dygIVALAdgevMB9pkvRdAdV+z+i/2aQpz</signature>
+</product>

--- a/etc/test_products/ci37645983/ci-origin-ci37645991-1494893051860.xml
+++ b/etc/test_products/ci37645983/ci-origin-ci37645991-1494893051860.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<product xmlns="http://earthquake.usgs.gov/distribution/product" id="urn:usgs-product:ci:origin:ci37645991:1494893051860" updateTime="2017-05-16T00:04:11.860Z" status="DELETE" trackerURL="http://prod01-pdl01.cr.usgs.gov/tracker">
+	<property name="eventParametersPublicID" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645991"/>
+	<property name="eventsource" value="ci"/>
+	<property name="eventsourcecode" value="37645991"/>
+	<property name="quakeml-publicid" value="quakeml:service.scedc.caltech.edu/fdsnws/event/1/query?eventid=37645991"/>
+	<property name="version" value="4"/>
+	<signature>MCwCFBnb41HvYxqPXvQUGkJEhuT2DCUGAhRFXfsfmrPDdejMT1gHoht+296Xkg==</signature>
+</product>

--- a/src/gov/usgs/earthquake/distribution/ProductClientTest.java
+++ b/src/gov/usgs/earthquake/distribution/ProductClientTest.java
@@ -76,9 +76,6 @@ public class ProductClientTest {
 		// Make sure we created 1 listener
 		List<NotificationListener> listeners = client.getListeners();
 		Assert.assertEquals(1, listeners.size());
-
-		return;
-
 	}
 
 	/**

--- a/src/gov/usgs/earthquake/eids/EventAddonParser.java
+++ b/src/gov/usgs/earthquake/eids/EventAddonParser.java
@@ -47,7 +47,7 @@ public class EventAddonParser extends SAXAdapter {
 			// convert the parsed addon to an EQMessage
 			return addon.getEQMessage();
 		} catch (SAXException e) {
-			if (!(e.getCause() instanceof java.text.ParseException)) {
+			if (!(e.getCause() instanceof ParseException)) {
 				throw e;
 			}
 		}

--- a/src/gov/usgs/earthquake/indexer/DefaultAssociator.java
+++ b/src/gov/usgs/earthquake/indexer/DefaultAssociator.java
@@ -104,8 +104,16 @@ public class DefaultAssociator implements Associator {
 				Event event = iter.next();
 
 				boolean sameSourceDifferentCode = false;
-				Iterator<ProductSummary> summaryIter = event.getProductList()
-						.iterator();
+				Iterator<ProductSummary> summaryIter;
+
+				if (event.isDeleted()) {
+					// ignore delete products before checking
+					summaryIter = Event.getWithoutSuperseded(
+							Event.getWithoutDeleted(event.getAllProductList())).iterator();
+				} else {
+					summaryIter = event.getProductList()
+							.iterator();
+				}
 				while (summaryIter.hasNext()) {
 					ProductSummary nextSummary = summaryIter.next();
 					if (summarySource.equalsIgnoreCase(nextSummary

--- a/src/gov/usgs/earthquake/indexer/IndexerSourceAndCodeNotUniqueTest.java
+++ b/src/gov/usgs/earthquake/indexer/IndexerSourceAndCodeNotUniqueTest.java
@@ -7,6 +7,7 @@ import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -78,23 +79,27 @@ public class IndexerSourceAndCodeNotUniqueTest {
 
 		indexer.startup();
 
-		Product product = null;
-		for (File file : PRODUCTS) {
-			product = ObjectProductHandler.getProduct(new XmlProductSource(StreamUtils
-					.getInputStream(file)));
-			indexer.onProduct(product);
-			
-			synchronized (SYNC) {
-				SYNC.wait();
-			}
-			IndexerEvent lastEvent = listener.getLastEvent();
+		try {
+			Product product = null;
+			for (File file : PRODUCTS) {
+				product = ObjectProductHandler.getProduct(new XmlProductSource(StreamUtils
+						.getInputStream(file)));
+				indexer.onProduct(product);
 
-			for (IndexerChange ev : lastEvent.getIndexerChanges()) {
-				System.err.println(ev.getType());
+				synchronized (SYNC) {
+					SYNC.wait();
+				}
+				IndexerEvent lastEvent = listener.getLastEvent();
+
+				for (IndexerChange ev : lastEvent.getIndexerChanges()) {
+					System.err.println(ev.getType());
+				}
 			}
+		} catch (Exception e) {
+			Assert.fail("Indexer threw exception while processing products");
+		} finally {
+			indexer.shutdown();
 		}
-
-		indexer.shutdown();
 	}
 
 	public class TestIndexerListener extends DefaultIndexerListener {

--- a/src/gov/usgs/earthquake/indexer/IndexerSourceAndCodeNotUniqueTest.java
+++ b/src/gov/usgs/earthquake/indexer/IndexerSourceAndCodeNotUniqueTest.java
@@ -60,7 +60,7 @@ public class IndexerSourceAndCodeNotUniqueTest {
 	
 
 	@Test
-	public void sourceAndCodeNotUniqueTest_ci37645983() throws Exception {
+	public void sourceAndCodeNotUniqueTestci37645983() throws Exception {
 		// turn up logging during test
 		LogManager.getLogManager().reset();
 		ConsoleHandler handler = new ConsoleHandler();

--- a/src/gov/usgs/earthquake/indexer/IndexerSourceAndCodeNotUniqueTest.java
+++ b/src/gov/usgs/earthquake/indexer/IndexerSourceAndCodeNotUniqueTest.java
@@ -105,9 +105,6 @@ public class IndexerSourceAndCodeNotUniqueTest {
 	public class TestIndexerListener extends DefaultIndexerListener {
 		private IndexerEvent lastIndexerEvent = null;
 
-		public TestIndexerListener() {
-		}
-
 		@Override
 		public void onIndexerEvent(final IndexerEvent event) {
 			try {

--- a/src/gov/usgs/earthquake/indexer/IndexerSourceAndCodeNotUniqueTest.java
+++ b/src/gov/usgs/earthquake/indexer/IndexerSourceAndCodeNotUniqueTest.java
@@ -1,0 +1,130 @@
+package gov.usgs.earthquake.indexer;
+
+import java.io.File;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import gov.usgs.earthquake.distribution.FileProductStorage;
+import gov.usgs.earthquake.product.Product;
+import gov.usgs.earthquake.product.io.ObjectProductHandler;
+import gov.usgs.earthquake.product.io.XmlProductSource;
+import gov.usgs.util.FileUtils;
+import gov.usgs.util.StreamUtils;
+import gov.usgs.util.logging.SimpleLogFormatter;
+
+public class IndexerSourceAndCodeNotUniqueTest {
+
+	
+	private static File STORAGE_FILE = new File("_test_storage");
+	private static File INDEX_FILE = new File("_test_index");
+
+	private static File[] PRODUCTS = {
+		new File("etc/test_products/ci37645983/ci-origin-ci37645983-1494867948050.xml"),
+		new File("etc/test_products/ci37645983/ci-origin-ci37645983-1494868047790.xml"),
+		new File("etc/test_products/ci37645983/ci-origin-ci37645991-1494868066040.xml"),
+		new File("etc/test_products/ci37645983/ci-origin-ci37645991-1494874160300.xml"),
+		new File("etc/test_products/ci37645983/ci-origin-ci37645991-1494874160350.xml"),
+		new File("etc/test_products/ci37645983/ci-origin-ci37645991-1494874160800.xml"),
+		new File("etc/test_products/ci37645983/ci-origin-ci37645991-1494874160830.xml"),
+		new File("etc/test_products/ci37645983/ci-origin-ci37645983-1494874177010.xml"),
+		new File("etc/test_products/ci37645983/ci-origin-ci37645983-1494874177050.xml"),
+		new File("etc/test_products/ci37645983/ci-origin-ci37645983-1494874177480.xml"),
+		new File("etc/test_products/ci37645983/ci-origin-ci37645983-1494874177530.xml"),
+		new File("etc/test_products/ci37645983/ci-origin-ci37645983-1494874177890.xml"),
+		// this is the product that causes the exception
+		new File("etc/test_products/ci37645983/ci-origin-ci37645983-1494892985010.xml"),
+		new File("etc/test_products/ci37645983/ci-origin-ci37645991-1494893051170.xml"),
+		new File("etc/test_products/ci37645983/ci-origin-ci37645991-1494893051860.xml")
+	};
+
+	private static final Object SYNC = new Object();
+
+	@Before
+	public void before() {
+		FileUtils.deleteTree(STORAGE_FILE);
+		FileUtils.deleteTree(INDEX_FILE);
+	}
+
+	@After
+	public void after() {
+		FileUtils.deleteTree(STORAGE_FILE);
+		FileUtils.deleteTree(INDEX_FILE);
+	}
+	
+
+	@Test
+	public void sourceAndCodeNotUniqueTest_ci37645983() throws Exception {
+		// turn up logging during test
+		LogManager.getLogManager().reset();
+		ConsoleHandler handler = new ConsoleHandler();
+		// handler.setLevel(Level.FINEST);
+		handler.setFormatter(new SimpleLogFormatter());
+		Logger rootLogger = Logger.getLogger("");
+		rootLogger.addHandler(handler);
+		rootLogger.setLevel(Level.FINEST);
+
+		Indexer indexer = new Indexer();
+		indexer.setProductIndex(new JDBCProductIndex(INDEX_FILE.getName()));
+		indexer.setProductStorage(new FileProductStorage(STORAGE_FILE));
+
+		TestIndexerListener listener = new TestIndexerListener();
+		indexer.addListener(listener);
+
+		indexer.startup();
+
+		Product product = null;
+		for (File file : PRODUCTS) {
+			product = ObjectProductHandler.getProduct(new XmlProductSource(StreamUtils
+					.getInputStream(file)));
+			indexer.onProduct(product);
+			
+			synchronized (SYNC) {
+				SYNC.wait();
+			}
+			IndexerEvent lastEvent = listener.getLastEvent();
+
+			for (IndexerChange ev : lastEvent.getIndexerChanges()) {
+				System.err.println(ev.getType());
+			}
+		}
+
+		indexer.shutdown();
+	}
+
+	public class TestIndexerListener extends DefaultIndexerListener {
+		private IndexerEvent lastIndexerEvent = null;
+
+		public TestIndexerListener() {
+		}
+
+		@Override
+		public void onIndexerEvent(final IndexerEvent event) {
+			try {
+				Thread.sleep(5);
+			} catch (InterruptedException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+			lastIndexerEvent = event;
+			synchronized (SYNC) {
+				SYNC.notify();
+			}
+		}
+
+		public IndexerEvent getLastEvent() throws InterruptedException {
+			return lastIndexerEvent;
+		}
+
+		public void clear() {
+			lastIndexerEvent = null;
+		}
+
+	}
+
+}

--- a/src/gov/usgs/earthquake/indexer/JDBCProductIndex.java
+++ b/src/gov/usgs/earthquake/indexer/JDBCProductIndex.java
@@ -301,7 +301,7 @@ public class JDBCProductIndex extends JDBCConnection implements ProductIndex {
 		try {
 			insertEvent = connection.prepareStatement(INSERT_EVENT_QUERY,
 					new String[] { EVENT_INDEX_ID });
-		} catch (java.sql.SQLException e) {
+		} catch (SQLException e) {
 			// sqlite doesn't support RETURN_GENERATED_KEYS, but appears to
 			// return generated keys anyways
 			insertEvent = connection.prepareStatement(INSERT_EVENT_QUERY);
@@ -1679,7 +1679,7 @@ public class JDBCProductIndex extends JDBCConnection implements ProductIndex {
 		String query_prefix = String
 				.format("SELECT * FROM %s p", SUMMARY_TABLE);
 		String query_suffix = "";
-		if (!whereClause.toString().equals("")) {
+		if (whereClause.length() > 0) {
 			query_suffix = String.format(" WHERE %s", whereClause.toString());
 		}
 		String query_text = query_prefix + query_suffix + " " + orderby;

--- a/src/gov/usgs/util/StreamUtils.java
+++ b/src/gov/usgs/util/StreamUtils.java
@@ -289,7 +289,7 @@ public class StreamUtils {
 		 * @param in
 		 *            the InputStream to wrap.
 		 */
-		public UnclosableInputStream(final java.io.InputStream in) {
+		public UnclosableInputStream(final InputStream in) {
 			super(in);
 		}
 
@@ -319,7 +319,7 @@ public class StreamUtils {
 		 * @param out
 		 *            the OutputStream to wrap.
 		 */
-		public UnclosableOutputStream(final java.io.OutputStream out) {
+		public UnclosableOutputStream(final OutputStream out) {
 			super(out);
 		}
 


### PR DESCRIPTION
This occurs when 2 events from the same network are within association distance, have both been deleted, and one is updated; because deleted products are ignored during the check.  This occurs most commonly in indexers processing only a subset of product types (in this case origin), which is a common use case.

This fix (when event is deleted, consider deleted products) passes all the other tests, however it may be better to handle the deleted event case more carefully.  Thoughts?