### PR TITLE
Update MB region

### DIFF
--- a/etc/config/regions.xml
+++ b/etc/config/regions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <regions>
 	<file name="regions.xml"/>
-	<update date="2017-07-06 14:00:00"/>
+	<update date="2017-07-07 11:00:00"/>
 	<format version="0.1"/>
 	<!--
 	# Region file for the ANSS (formerly CNSS) catalog
@@ -135,6 +135,25 @@
 			http://earthquake.usgs.gov/research/monitoring/anss/regions/ne/
 		</MsgSourceOfInfo>
 		<MsgShortInfo desc="Lamont-Doherty Obs"/>
+	</net>
+	<net code="MB" name="montana">
+		<region code="MB">
+			<coordinate latitude="41.2000" longitude="-160.0000"/>
+			<coordinate latitude="41.3000" longitude="-160.0000"/>
+			<coordinate latitude="41.3000" longitude="-159.9000"/>
+			<coordinate latitude="41.2000" longitude="-159.9000"/>
+			<coordinate latitude="41.2000" longitude="-160.0000"/>
+		</region>
+		<MsgHeaderText>
+			Montana Bureau of Mines and Geology
+			http://mbmgquake.mtech.edu/
+		</MsgHeaderText>
+		<MsgMoreInfo link="http://earthquake.usgs.gov/eqcenter/recenteqsus"/>
+		<MsgSourceOfInfo>
+			Montana Bureau of Mines and Geology
+			http://earthquake.usgs.gov/research/monitoring/anss/regions/imw/
+		</MsgSourceOfInfo>
+		<MsgShortInfo desc="MT Bureau Mines Geology"/>
 	</net>
 	<net code="NC" name="ncsn">
 		<region code="NC">

--- a/src/gov/usgs/earthquake/distribution/ProductClient.java
+++ b/src/gov/usgs/earthquake/distribution/ProductClient.java
@@ -62,7 +62,7 @@ public class ProductClient extends DefaultConfigurable implements
 		ProductClientMBean, Bootstrappable {
 
 	/** The "release" version number. */
-	public static final String RELEASE_VERSION = "Version 1.13.0 2017-07-06";
+	public static final String RELEASE_VERSION = "Version 1.13.1 2017-07-07";
 
 	/** Property name used on products for current RELEASE_VERSION. */
 	public static final String PDL_CLIENT_VERSION_PROPERTY = "pdl-client-version";


### PR DESCRIPTION
Add MB region back, but make region very small. This should keep MB solutions from becoming authoritative.

It looks like if a region doesn't exist in regions.xml, and they submit a solution, then that region has the same authority as NEIC. This means that the latest product becomes authoritative. Fix this by adding a small MB region in the pacific (like AT/PT).

