### PR TITLE
Refactor authoritative region check for networks with multiple regions

### DIFF
--- a/src/main/java/gov/usgs/earthquake/qdm/Regions.java
+++ b/src/main/java/gov/usgs/earthquake/qdm/Regions.java
@@ -79,6 +79,9 @@ public class Regions {
         if (this.isDefaultNetID(netid)) {
             // if any non-default regions match, default is not authoritative
             for (Region region : this.regions) {
+                if (netid.equalsIgnoreCase(region.netid)) {
+                    continue;
+                }
                 if (region.inpoly(p)) {
                     // another region is authoritative
                     return false;

--- a/src/main/java/gov/usgs/earthquake/qdm/Regions.java
+++ b/src/main/java/gov/usgs/earthquake/qdm/Regions.java
@@ -1,10 +1,12 @@
 package gov.usgs.earthquake.qdm;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Set of regions.
- *  
+ *
  * @author - Alan Jones, 1999.09.10 <br>
  *         2002.01.16: Convert from "regions" directory with above files to
  *         regions.xml file. <br>
@@ -45,7 +47,7 @@ public class Regions {
 
     /**
      * Checks if network ID is the default network.
-     * 
+     *
      * @param netid network ID
      * @return true if default network.
      */
@@ -55,7 +57,7 @@ public class Regions {
 
     /**
      * Checks if an event's network ID is the default network.
-     * 
+     *
      * @param eq EQ event
      * @return true if default network.
      */
@@ -70,39 +72,46 @@ public class Regions {
 
     /**
      * Determines if the event is from the authoritative network.
-     * 
+     *
      * @param netid network ID
      * @param p     event point
      * @return true if event is authoritative
      */
     public boolean isAuthor(final String netid, final Point p) {
         if (this.isDefaultNetID(netid)) {
-            // default region is authoritative where others are not.
-            for (Region region : this.regions) {
-                if (region.netid.equalsIgnoreCase(netid)) {
-                    // default region includes all points
-                    continue;
-                }
+            // filter default region from list
+            List<Region> regions = this.regions.stream()
+                    .filter(region -> !this.isDefaultNetID(region.netid))
+                    .collect(Collectors.toList());
+            // if any non-default regions match, default is not authoritative
+            for (Region region : regions) {
                 if (region.inpoly(p)) {
-                    // if any region is authoritative, default is not
+                    // another region is authoritative
                     return false;
                 }
             }
+            // no other regions authoritative
             return true;
         } else {
-            // non-default regions are authoritative in their own region
-            for (Region region : this.regions) {
-                if (region.netid.equalsIgnoreCase(netid)) {
-                    return region.inpoly(p);
+            // filter to regions for network
+            List<Region> regions = this.regions.stream()
+                    .filter(region -> netid.equalsIgnoreCase(region.netid))
+                    .collect(Collectors.toList());
+            // if any network regions match, network is authoritative
+            for (Region region : regions) {
+                if (region.inpoly(p)) {
+                    // network is authoriative
+                    return true;
                 }
             }
+            // network is not authoritative
             return false;
         }
     }
 
     /**
      * Determines if the event is from the authoritative network.
-     * 
+     *
      * @param eq EQ event
      * @return true if event is authoritative
      */

--- a/src/main/java/gov/usgs/earthquake/qdm/Regions.java
+++ b/src/main/java/gov/usgs/earthquake/qdm/Regions.java
@@ -13,8 +13,8 @@ import java.util.ArrayList;
  *         default network (US), add isAuthor method to check if the event is
  *         authoritative
  *
- *         2018-08-21: JMF, reimplement parsing logic outside class.
- *         Update code to Java 1.8+.
+ *         2018-08-21: JMF, reimplement parsing logic outside class. Update code
+ *         to Java 1.8+.
  */
 public class Regions {
 
@@ -79,7 +79,7 @@ public class Regions {
         if (this.isDefaultNetID(netid)) {
             // if any non-default regions match, default is not authoritative
             for (Region region : this.regions) {
-                if (netid.equalsIgnoreCase(region.netid)) {
+                if (region.netid.equalsIgnoreCase(netid)) {
                     continue;
                 }
                 if (region.inpoly(p)) {
@@ -92,7 +92,7 @@ public class Regions {
         } else {
             // if any network regions match, network is authoritative
             for (Region region : regions) {
-                if (netid.equalsIgnoreCase(region.netid) && region.inpoly(p)) {
+                if (region.netid.equalsIgnoreCase(netid) && region.inpoly(p)) {
                     // network is authoritative
                     return true;
                 }

--- a/src/main/java/gov/usgs/earthquake/qdm/Regions.java
+++ b/src/main/java/gov/usgs/earthquake/qdm/Regions.java
@@ -1,8 +1,6 @@
 package gov.usgs.earthquake.qdm;
 
 import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Set of regions.
@@ -79,12 +77,8 @@ public class Regions {
      */
     public boolean isAuthor(final String netid, final Point p) {
         if (this.isDefaultNetID(netid)) {
-            // filter default region from list
-            List<Region> regions = this.regions.stream()
-                    .filter(region -> !this.isDefaultNetID(region.netid))
-                    .collect(Collectors.toList());
             // if any non-default regions match, default is not authoritative
-            for (Region region : regions) {
+            for (Region region : this.regions) {
                 if (region.inpoly(p)) {
                     // another region is authoritative
                     return false;
@@ -93,14 +87,10 @@ public class Regions {
             // no other regions authoritative
             return true;
         } else {
-            // filter to regions for network
-            List<Region> regions = this.regions.stream()
-                    .filter(region -> netid.equalsIgnoreCase(region.netid))
-                    .collect(Collectors.toList());
             // if any network regions match, network is authoritative
             for (Region region : regions) {
-                if (region.inpoly(p)) {
-                    // network is authoriative
+                if (netid.equalsIgnoreCase(region.netid) && region.inpoly(p)) {
+                    // network is authoritative
                     return true;
                 }
             }


### PR DESCRIPTION
Networks may have multiple regions (e.g. UU has Utah and a section of Wyoming).

Current behavior stops after first region does not match.  This updates the check to be a little clearer, and test all candidate regions before returning false.