### PR TITLE
Origin Indexer Module

### DIFF
--- a/src/main/java/gov/usgs/earthquake/geoserve/GeoservePlaces.java
+++ b/src/main/java/gov/usgs/earthquake/geoserve/GeoservePlaces.java
@@ -1,0 +1,22 @@
+package gov.usgs.earthquake.geoserve;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.net.MalformedURLException;
+
+public interface GeoservePlaces {
+  /**
+   * Uses the location information provided in order to generate an event title
+   * from data obtained from the GeoservePlaces endpoint.
+   *
+   * @param latitude  Decimal degrees latitude for the location of interest
+   * @param longitude Decimal degrees longitude for the location of interest
+   *
+   * @throws IOException           If the GeoesrvePlaces endpoint can not be
+   *                               contacted
+   * @throws MalformedURLException If the configured endpoint URL is invalid
+   */
+  public String getEventTitle(BigDecimal latitude, BigDecimal longitude) throws IOException, MalformedURLException;
+
+  // TODO :: Add other methods to this interface
+}

--- a/src/main/java/gov/usgs/earthquake/geoserve/GeoservePlacesService.java
+++ b/src/main/java/gov/usgs/earthquake/geoserve/GeoservePlacesService.java
@@ -1,0 +1,53 @@
+package gov.usgs.earthquake.geoserve;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+import gov.usgs.util.StreamUtils;
+
+public class GeoservePlacesService {
+  /** Default URL for GeoServe Places service. */
+  public static final String DEFAULT_GEOSERVE_PLACES_URL = "https://earthquake.usgs.gov/ws/geoserve/places.json";
+
+  /** Configured URL for GeoServe Places service. */
+  private String endpointUrl;
+
+  public GeoservePlacesService() {
+    this(DEFAULT_GEOSERVE_PLACES_URL);
+  }
+
+  public GeoservePlacesService(final String endpointUrl) {
+    this.endpointUrl = endpointUrl;
+  }
+
+  public String getEndpointURL() {
+    return this.endpointUrl;
+  }
+
+  public void setEndpointURL(final String endpointUrl) {
+    this.endpointUrl = endpointUrl;
+  }
+
+  public JsonObject getEventPlaces(BigDecimal latitude, BigDecimal longitude)
+      throws IOException, MalformedURLException {
+    final URL url = new URL(String.format("%s?type=event&latitude=%s&longitude=%s", this.endpointUrl,
+        URLEncoder.encode(latitude.toString(), "UTF-8"), URLEncoder.encode(longitude.toString(), "UTF-8")));
+
+    try (InputStream in = StreamUtils.getInputStream(url)) {
+      JsonReader reader = Json.createReader(in);
+      JsonObject json = reader.readObject();
+      reader.close();
+      return json.getJsonObject("event");
+    }
+  }
+
+  // TODO as needed, implement full GeoServe places API options
+}

--- a/src/main/java/gov/usgs/earthquake/geoserve/GeoservePlacesService.java
+++ b/src/main/java/gov/usgs/earthquake/geoserve/GeoservePlacesService.java
@@ -14,7 +14,7 @@ import javax.json.JsonReader;
 
 import gov.usgs.util.StreamUtils;
 
-public class GeoservePlacesService {
+public class GeoservePlacesService implements GeoservePlaces {
   /** Default URL for GeoServe Places service. */
   public static final String DEFAULT_GEOSERVE_PLACES_URL = "https://earthquake.usgs.gov/ws/geoserve/places.json";
 

--- a/src/main/java/gov/usgs/earthquake/origin/OriginIndexerModule.java
+++ b/src/main/java/gov/usgs/earthquake/origin/OriginIndexerModule.java
@@ -37,62 +37,24 @@ public class OriginIndexerModule extends DefaultIndexerModule {
   // @Override
   public ProductSummary getProductSummary(Product product) throws Exception {
     ProductSummary summary = super.getProductSummary(product);
+    BigDecimal latitude = summary.getEventLatitude();
+    BigDecimal longitude = summary.getEventLongitude();
 
     // Defer to existing title property if set...
     Map<String, String> summaryProperties = summary.getProperties();
     String title = summaryProperties.get("title");
 
-    if (title == null) {
-      BigDecimal latitude = summary.getEventLatitude();
-      BigDecimal longitude = summary.getEventLongitude();
-
-      JsonObject places = this.geoservePlaces.getEventPlaces(latitude, longitude);
-      JsonArray features = places.getJsonArray("features");
-      JsonObject feature = features.get(0).asJsonObject();
-      JsonObject properties = feature.getJsonObject("properties");
-
-      String name = properties.getString("name");
-      String country = properties.getString("country_code").toLowerCase();
-      String admin = properties.getString("country_name");
-      int distance = properties.getInt("distance");
-      double azimuth = properties.getJsonNumber("azimuth").doubleValue();
-      String direction = azimuthToDirection(azimuth);
-
-      if ("us".equals(country)) {
-        admin = properties.getString("admin1_name");
+    if (title == null && latitude != null && longitude != null) {
+      try {
+        title = this.geoservePlaces.getEventTitle(latitude, longitude);
+        summaryProperties.put("title", title);
+      } catch (Exception ex) {
+        LOGGER.finer(ex.getMessage());
+        // Do nothing, value-added failed. Move on.
       }
-
-      title = String.format("%d km %s of %s, %s", distance, direction, name, admin);
-      summaryProperties.put("title", title);
-      // summaryProperties.put("region", title);
     }
 
     return summary;
-  }
-
-  /**
-   * Converts a decimal degree azimuth to a canonical compass direction
-   *
-   * @param {Number} azimuth The degrees azimuth to be converted
-   *
-   * @return {String} The canonical compass direction for the given input azimuth
-   */
-  public String azimuthToDirection(double azimuth) {
-    double fullwind = 22.5;
-    String[] directions = { "N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW",
-        "NNW", "N" };
-
-    // Invert azimuth for proper directivity
-    // Maybe not needed in the future.
-    azimuth += 180.0;
-
-    // adjust azimuth if negative
-    azimuth = Math.abs(azimuth);
-    while (azimuth < 0.0) {
-      azimuth = azimuth + 360.0;
-    }
-
-    return directions[(int) Math.round((azimuth % 360.0) / fullwind)];
   }
 
 }

--- a/src/main/java/gov/usgs/earthquake/origin/OriginIndexerModule.java
+++ b/src/main/java/gov/usgs/earthquake/origin/OriginIndexerModule.java
@@ -42,7 +42,7 @@ public class OriginIndexerModule extends DefaultIndexerModule {
         title = this.geoservePlaces.getEventTitle(latitude, longitude);
         summaryProperties.put("title", title);
       } catch (Exception ex) {
-        LOGGER.finer(ex.getMessage());
+        LOGGER.fine(ex.getMessage());
         // Do nothing, value-added failed. Move on.
       }
     }

--- a/src/main/java/gov/usgs/earthquake/origin/OriginIndexerModule.java
+++ b/src/main/java/gov/usgs/earthquake/origin/OriginIndexerModule.java
@@ -4,9 +4,6 @@ import java.math.BigDecimal;
 import java.util.Map;
 import java.util.logging.Logger;
 
-import javax.json.JsonArray;
-import javax.json.JsonObject;
-
 import gov.usgs.earthquake.geoserve.GeoservePlacesService;
 import gov.usgs.earthquake.indexer.DefaultIndexerModule;
 import gov.usgs.earthquake.indexer.IndexerModule;

--- a/src/main/java/gov/usgs/earthquake/origin/OriginIndexerModule.java
+++ b/src/main/java/gov/usgs/earthquake/origin/OriginIndexerModule.java
@@ -24,7 +24,7 @@ public class OriginIndexerModule extends DefaultIndexerModule {
     int supportLevel = IndexerModule.LEVEL_UNSUPPORTED;
     String type = getBaseProductType(product.getId().getType());
 
-    if ("origin".equals(type) && "update".equalsIgnoreCase(product.getStatus())) {
+    if ("origin".equals(type) && !"DELETE".equalsIgnoreCase(product.getStatus())) {
       supportLevel = IndexerModule.LEVEL_SUPPORTED;
     }
 

--- a/src/main/java/gov/usgs/earthquake/origin/OriginIndexerModule.java
+++ b/src/main/java/gov/usgs/earthquake/origin/OriginIndexerModule.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.util.Map;
 import java.util.logging.Logger;
 
+import gov.usgs.earthquake.geoserve.GeoservePlaces;
 import gov.usgs.earthquake.geoserve.GeoservePlacesService;
 import gov.usgs.earthquake.indexer.DefaultIndexerModule;
 import gov.usgs.earthquake.indexer.IndexerModule;
@@ -13,25 +14,20 @@ import gov.usgs.earthquake.product.Product;
 public class OriginIndexerModule extends DefaultIndexerModule {
   private static final Logger LOGGER = Logger.getLogger(OriginIndexerModule.class.getName());
 
-  private GeoservePlacesService geoservePlaces;
+  private GeoservePlaces geoservePlaces;
 
   public OriginIndexerModule() {
     this.geoservePlaces = new GeoservePlacesService();
   }
 
-  @Override
-  public int getSupportLevel(Product product) {
-    int supportLevel = IndexerModule.LEVEL_UNSUPPORTED;
-    String type = getBaseProductType(product.getId().getType());
-
-    if ("origin".equals(type) && !"DELETE".equalsIgnoreCase(product.getStatus())) {
-      supportLevel = IndexerModule.LEVEL_SUPPORTED;
-    }
-
-    return supportLevel;
+  /**
+   * @return The places service currently being used for title generation
+   */
+  public GeoservePlaces getPlacesService() {
+    return this.geoservePlaces;
   }
 
-  // @Override
+  @Override
   public ProductSummary getProductSummary(Product product) throws Exception {
     ProductSummary summary = super.getProductSummary(product);
     BigDecimal latitude = summary.getEventLatitude();
@@ -54,4 +50,25 @@ public class OriginIndexerModule extends DefaultIndexerModule {
     return summary;
   }
 
+  @Override
+  public int getSupportLevel(Product product) {
+    int supportLevel = IndexerModule.LEVEL_UNSUPPORTED;
+    String type = getBaseProductType(product.getId().getType());
+
+    if ("origin".equals(type) && !"DELETE".equalsIgnoreCase(product.getStatus())) {
+      supportLevel = IndexerModule.LEVEL_SUPPORTED;
+    }
+
+    return supportLevel;
+  }
+
+  /**
+   * Set the geoservePlaces to be used for subsequent calls to GeoServe places
+   * endpoint.
+   *
+   * @param geoservePlaces The GeoservePlaces to use
+   */
+  public void setPlacesService(GeoservePlaces geoservePlaces) {
+    this.geoservePlaces = geoservePlaces;
+  }
 }

--- a/src/main/java/gov/usgs/earthquake/origin/OriginIndexerModule.java
+++ b/src/main/java/gov/usgs/earthquake/origin/OriginIndexerModule.java
@@ -1,0 +1,98 @@
+package gov.usgs.earthquake.origin;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+
+import gov.usgs.earthquake.geoserve.GeoservePlacesService;
+import gov.usgs.earthquake.indexer.DefaultIndexerModule;
+import gov.usgs.earthquake.indexer.IndexerModule;
+import gov.usgs.earthquake.indexer.ProductSummary;
+import gov.usgs.earthquake.product.Product;
+
+public class OriginIndexerModule extends DefaultIndexerModule {
+  private static final Logger LOGGER = Logger.getLogger(OriginIndexerModule.class.getName());
+
+  private GeoservePlacesService geoservePlaces;
+
+  public OriginIndexerModule() {
+    this.geoservePlaces = new GeoservePlacesService();
+  }
+
+  @Override
+  public int getSupportLevel(Product product) {
+    int supportLevel = IndexerModule.LEVEL_UNSUPPORTED;
+    String type = getBaseProductType(product.getId().getType());
+
+    if ("origin".equals(type) && "update".equalsIgnoreCase(product.getStatus())) {
+      supportLevel = IndexerModule.LEVEL_SUPPORTED;
+    }
+
+    return supportLevel;
+  }
+
+  // @Override
+  public ProductSummary getProductSummary(Product product) throws Exception {
+    ProductSummary summary = super.getProductSummary(product);
+
+    // Defer to existing title property if set...
+    Map<String, String> summaryProperties = summary.getProperties();
+    String title = summaryProperties.get("title");
+
+    if (title == null) {
+      BigDecimal latitude = summary.getEventLatitude();
+      BigDecimal longitude = summary.getEventLongitude();
+
+      JsonObject places = this.geoservePlaces.getEventPlaces(latitude, longitude);
+      JsonArray features = places.getJsonArray("features");
+      JsonObject feature = features.get(0).asJsonObject();
+      JsonObject properties = feature.getJsonObject("properties");
+
+      String name = properties.getString("name");
+      String country = properties.getString("country_code").toLowerCase();
+      String admin = properties.getString("country_name");
+      int distance = properties.getInt("distance");
+      double azimuth = properties.getJsonNumber("azimuth").doubleValue();
+      String direction = azimuthToDirection(azimuth);
+
+      if ("us".equals(country)) {
+        admin = properties.getString("admin1_name");
+      }
+
+      title = String.format("%d km %s of %s, %s", distance, direction, name, admin);
+      summaryProperties.put("title", title);
+      // summaryProperties.put("region", title);
+    }
+
+    return summary;
+  }
+
+  /**
+   * Converts a decimal degree azimuth to a canonical compass direction
+   *
+   * @param {Number} azimuth The degrees azimuth to be converted
+   *
+   * @return {String} The canonical compass direction for the given input azimuth
+   */
+  public String azimuthToDirection(double azimuth) {
+    double fullwind = 22.5;
+    String[] directions = { "N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW",
+        "NNW", "N" };
+
+    // Invert azimuth for proper directivity
+    // Maybe not needed in the future.
+    azimuth += 180.0;
+
+    // adjust azimuth if negative
+    azimuth = Math.abs(azimuth);
+    while (azimuth < 0.0) {
+      azimuth = azimuth + 360.0;
+    }
+
+    return directions[(int) Math.round((azimuth % 360.0) / fullwind)];
+  }
+
+}

--- a/src/test/java/gov/usgs/earthquake/geoserve/GeoservePlacesServiceTest.java
+++ b/src/test/java/gov/usgs/earthquake/geoserve/GeoservePlacesServiceTest.java
@@ -1,0 +1,56 @@
+package gov.usgs.earthquake.geoserve;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GeoservePlacesServiceTest {
+
+  private GeoservePlacesService service = null;
+
+  @Before
+  public void setUpTestEnvironment() {
+    service = new GeoservePlacesService();
+  }
+
+  @Test
+  public void azimuthToDirection() {
+    Assert.assertEquals("S", service.azimuthToDirection(0));
+    Assert.assertEquals("W", service.azimuthToDirection(90));
+    Assert.assertEquals("N", service.azimuthToDirection(180));
+    Assert.assertEquals("E", service.azimuthToDirection(270));
+
+    Assert.assertEquals("S", service.azimuthToDirection(-0));
+    Assert.assertEquals("E", service.azimuthToDirection(-90));
+    Assert.assertEquals("N", service.azimuthToDirection(-180));
+    Assert.assertEquals("W", service.azimuthToDirection(-270));
+  }
+
+  @Test
+  public void formatEventTitle() {
+    int distance = 0;
+    double azimuth = 0.0;
+
+    // OUS location
+    String expectation = String.format("0 km S of name, country_name");
+    JsonObject feature = Json.createObjectBuilder()
+        .add("properties",
+            Json.createObjectBuilder().add("name", "name").add("country_code", "country_code")
+                .add("admin1_name", "admin1_name").add("country_name", "country_name").add("distance", distance)
+                .add("azimuth", azimuth))
+        .build();
+    Assert.assertEquals(expectation, service.formatEventTitle(feature));
+
+    // US location
+    expectation = String.format("0 km S of name, admin1_name");
+    feature = Json.createObjectBuilder()
+        .add("properties",
+            Json.createObjectBuilder().add("name", "name").add("country_code", "us").add("admin1_name", "admin1_name")
+                .add("country_name", "country_name").add("distance", distance).add("azimuth", azimuth))
+        .build();
+    Assert.assertEquals(expectation, service.formatEventTitle(feature));
+  }
+}

--- a/src/test/java/gov/usgs/earthquake/origin/OriginIndexerModuleTest.java
+++ b/src/test/java/gov/usgs/earthquake/origin/OriginIndexerModuleTest.java
@@ -1,0 +1,101 @@
+package gov.usgs.earthquake.origin;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.net.MalformedURLException;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import gov.usgs.earthquake.geoserve.GeoservePlaces;
+import gov.usgs.earthquake.indexer.IndexerModule;
+import gov.usgs.earthquake.indexer.ProductSummary;
+import gov.usgs.earthquake.product.Product;
+import gov.usgs.earthquake.product.ProductId;
+
+public class OriginIndexerModuleTest {
+
+  private OriginIndexerModule module = null;
+
+  @Before
+  public void setUpTestEnvironment() throws Exception {
+    module = new OriginIndexerModule();
+  }
+
+  @Test
+  public void getSupportLevel() throws Exception {
+    ProductId id = new ProductId("unit", "origin", "test");
+
+    // Does support origin products with non-delete status
+    Product product = new Product(id, "UPDATE");
+    int supportLevel = module.getSupportLevel(product);
+    Assert.assertEquals(IndexerModule.LEVEL_SUPPORTED, supportLevel);
+
+    product = new Product(id, "DELETE");
+    supportLevel = module.getSupportLevel(product);
+    Assert.assertEquals(IndexerModule.LEVEL_UNSUPPORTED, supportLevel);
+
+    product = new Product(id, "SOME_OTHER_STATUS");
+    supportLevel = module.getSupportLevel(product);
+    Assert.assertEquals(IndexerModule.LEVEL_SUPPORTED, supportLevel);
+
+    // Does not support non-origin products
+    id = new ProductId("unit", "NotAnOrigin", "test");
+    product = new Product(id, "UPDATE");
+    supportLevel = module.getSupportLevel(product);
+    Assert.assertEquals(IndexerModule.LEVEL_UNSUPPORTED, supportLevel);
+
+    product = new Product(id, "DELETE");
+    supportLevel = module.getSupportLevel(product);
+    Assert.assertEquals(IndexerModule.LEVEL_UNSUPPORTED, supportLevel);
+
+    product = new Product(id, "SOME_OTHER_STATUS");
+    supportLevel = module.getSupportLevel(product);
+    Assert.assertEquals(IndexerModule.LEVEL_UNSUPPORTED, supportLevel);
+  }
+
+  @Test
+  public void getProductSummary() throws Exception {
+    GeoservePlaces service = new DummyPlacesService();
+    ProductId id = new ProductId("unit", "origin", "test");
+    String defaultTitle = "event title";
+    Product product = null;
+    ProductSummary summary = null;
+    BigDecimal latitude = new BigDecimal("0.0");
+    BigDecimal longitude = new BigDecimal("0.0");
+
+    module.setPlacesService(service);
+
+    // Product has no title and no coordinates, do not generate title
+    product = new Product(id);
+    summary = module.getProductSummary(product);
+    Assert.assertNull(summary.getProperties().get("title"));
+
+    // Product has title, but no coordinates, do not generate title
+    product = new Product(id);
+    product.getProperties().put("title", defaultTitle);
+    summary = module.getProductSummary(product);
+    Assert.assertEquals(defaultTitle, summary.getProperties().get("title"));
+
+    // Product has title and coordinates, do not generate title
+    product = new Product(id);
+    product.getProperties().put("title", defaultTitle);
+    summary = module.getProductSummary(product);
+    Assert.assertEquals(defaultTitle, summary.getProperties().get("title"));
+
+    // Product has no title, but does have coordinates, generate title
+    product = new Product(id);
+    product.setLatitude(latitude);
+    product.setLongitude(longitude);
+    summary = module.getProductSummary(product);
+    Assert.assertEquals(service.getEventTitle(latitude, longitude), summary.getProperties().get("title"));
+  }
+
+  protected class DummyPlacesService implements GeoservePlaces {
+    @Override
+    public String getEventTitle(BigDecimal latitude, BigDecimal longitude) throws IOException, MalformedURLException {
+      return String.format("Dummy Response: %f, %f", latitude.doubleValue(), longitude.doubleValue());
+    }
+  }
+}


### PR DESCRIPTION
Creates an indexer module for origin type products. When an origin arrives, the product is summarized and a `title` property is generated based on the origin parameters using the geoserve web service.

Subsequently [part of feeds app], event summarization looks for a title property on the preferred origin and uses that as the place/region in summarization in the index database [eventSummary table].

Using this module for indexers would allow them to exclude `geoserve` type products and eventually `geoserve` type products could stop being sent altogether.