### PR TITLE
Timeout updates

### DIFF
--- a/code.json
+++ b/code.json
@@ -27,7 +27,7 @@
       "email": "jmfee@usgs.gov"
     },
     "date": {
-      "metadataLastUpdated": "2020-12-01"
+      "metadataLastUpdated": "2020-12-03"
     }
   }
 ]

--- a/code.json
+++ b/code.json
@@ -3,7 +3,7 @@
     "name": "Product Distribution Layer",
     "organization": "U.S. Geological Survey",
     "description": "Distribution system used for derived earthquake information",
-    "version": "v2.6.1",
+    "version": "v2.7.0",
     "status": "Production",
     "permissions": {
       "usageType": "openSource",
@@ -27,7 +27,7 @@
       "email": "jmfee@usgs.gov"
     },
     "date": {
-      "metadataLastUpdated": "2020-11-30"
+      "metadataLastUpdated": "2020-12-01"
     }
   }
 ]

--- a/code.json
+++ b/code.json
@@ -3,7 +3,7 @@
     "name": "Product Distribution Layer",
     "organization": "U.S. Geological Survey",
     "description": "Distribution system used for derived earthquake information",
-    "version": "v2.6.0",
+    "version": "v2.6.1",
     "status": "Production",
     "permissions": {
       "usageType": "openSource",
@@ -27,7 +27,7 @@
       "email": "jmfee@usgs.gov"
     },
     "date": {
-      "metadataLastUpdated": "2020-11-20"
+      "metadataLastUpdated": "2020-11-30"
     }
   }
 ]

--- a/src/main/java/gov/usgs/earthquake/aws/AwsProductReceiver.java
+++ b/src/main/java/gov/usgs/earthquake/aws/AwsProductReceiver.java
@@ -48,8 +48,6 @@ public class AwsProductReceiver extends DefaultNotificationReceiver implements W
   private String trackingFileName;
   private int attempts;
   private long timeout;
-  // default expiration for notifications
-  private long expirationAge = 7 * 86400 * 1000;
 
   private TrackingIndex trackingIndex;
   private WebSocketClient client;

--- a/src/main/java/gov/usgs/earthquake/aws/AwsProductReceiver.java
+++ b/src/main/java/gov/usgs/earthquake/aws/AwsProductReceiver.java
@@ -48,6 +48,8 @@ public class AwsProductReceiver extends DefaultNotificationReceiver implements W
   private String trackingFileName;
   private int attempts;
   private long timeout;
+  // default expiration for notifications
+  private long expirationAge = 7 * 86400 * 1000;
 
   private TrackingIndex trackingIndex;
   private WebSocketClient client;

--- a/src/main/java/gov/usgs/earthquake/aws/AwsProductSender.java
+++ b/src/main/java/gov/usgs/earthquake/aws/AwsProductSender.java
@@ -47,6 +47,12 @@ public class AwsProductSender extends DefaultConfigurable implements ProductSend
   // whether to sign products
   protected boolean signProducts = false;
 
+  // 5s seems excessive, but be cautious for now
+  protected int connectTimeout = 5000;
+  // this corresponds to server-side timeout
+  // read timeout applies once getInputStream().read() is called
+  protected int readTimeout = 30000;
+
   public AwsProductSender() {}
 
   @Override
@@ -186,6 +192,8 @@ public class AwsProductSender extends DefaultConfigurable implements ProductSend
     // send as attribute, for extensibility
     final JsonObject json = Json.createObjectBuilder().add("product", product).build();
     HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    connection.setConnectTimeout(connectTimeout);
+    connection.setReadTimeout(readTimeout);
     connection.setDoOutput(true);
     connection.setRequestMethod("POST");
     connection.setRequestProperty("Content-Type", "application/json");
@@ -249,6 +257,8 @@ public class AwsProductSender extends DefaultConfigurable implements ProductSend
     final long start = new Date().getTime();
     final HttpURLConnection connection = (HttpURLConnection) signedUrl.openConnection();
     connection.setDoOutput(true);
+    connection.setConnectTimeout(connectTimeout);
+    connection.setReadTimeout(readTimeout);
     // these values are part of signed url and are required
     connection.setRequestMethod("PUT");
     connection.addRequestProperty("Content-Length", content.getLength().toString());

--- a/src/main/java/gov/usgs/earthquake/aws/HttpException.java
+++ b/src/main/java/gov/usgs/earthquake/aws/HttpException.java
@@ -10,8 +10,8 @@ class HttpException extends Exception {
 
   public final HttpResponse response;
 
-  public HttpException(final HttpResponse response, final String cause) {
-    super(cause);
+  public HttpException(final HttpResponse response, final String message) {
+    super(message);
     this.response = response;
   }
 

--- a/src/main/java/gov/usgs/earthquake/aws/JsonNotification.java
+++ b/src/main/java/gov/usgs/earthquake/aws/JsonNotification.java
@@ -54,10 +54,18 @@ public class JsonNotification extends URLNotification {
    * Create a JsonNotification from an existing Product.
    */
   JsonNotification(final Instant created, final Product product) throws Exception {
+    this(created, product, new Date(Instant.now().plusSeconds(7 * 86400).toEpochMilli()));
+  }
+
+  /**
+   * Create a JsonNotification with an expiration date.
+   */
+  JsonNotification(final Instant created, final Product product, final Date expiration)
+      throws Exception {
     super(
         product.getId(),
         // expiration date
-        new Date(created.plusSeconds(30 * 86400).toEpochMilli()),
+        expiration,
         // no tracker
         EMPTY_URL,
         // store product as data url
@@ -68,4 +76,5 @@ public class JsonNotification extends URLNotification {
     this.created = created;
     this.product = product;
   }
+
 }

--- a/src/main/java/gov/usgs/earthquake/distribution/DefaultNotificationReceiver.java
+++ b/src/main/java/gov/usgs/earthquake/distribution/DefaultNotificationReceiver.java
@@ -93,6 +93,7 @@ public class DefaultNotificationReceiver extends DefaultConfigurable implements
 
 	public static final String LISTENER_NOTIFIER_PROPERTY = "listenerNotifier";
 	public static final String EXECUTOR_LISTENER_NOTIFIER = "executor";
+	public static final String FUTURE_LISTENER_NOTIFIER = "future";
 	public static final String ROUNDROBIN_LISTENER_NOTIFIER = "roundrobin";
 
 	/** The notification index where received notifications are stored. */
@@ -119,7 +120,7 @@ public class DefaultNotificationReceiver extends DefaultConfigurable implements
 	private ObjectLock<ProductId> retrieveLocks = new ObjectLock<ProductId>();
 
 	public DefaultNotificationReceiver() {
-		notifier = new ExecutorListenerNotifier(this);
+		notifier = new FutureListenerNotifier(this);
 	}
 
 	/**
@@ -565,6 +566,8 @@ public class DefaultNotificationReceiver extends DefaultConfigurable implements
 				notifier = new ExecutorListenerNotifier(this);
 				LOGGER.config("[" + getName()
 						+ "] using executor listener notifier");
+			} else if (notifierType.equals(FUTURE_LISTENER_NOTIFIER)) {
+				notifier = new FutureListenerNotifier(this);
 			} else if (notifierType.equals(ROUNDROBIN_LISTENER_NOTIFIER)) {
 				notifier = new RoundRobinListenerNotifier(this);
 				LOGGER.config("[" + getName()

--- a/src/main/java/gov/usgs/earthquake/distribution/ExecutorListenerNotifier.java
+++ b/src/main/java/gov/usgs/earthquake/distribution/ExecutorListenerNotifier.java
@@ -1,5 +1,6 @@
 package gov.usgs.earthquake.distribution;
 
+import gov.usgs.earthquake.aws.JsonNotificationIndex;
 import gov.usgs.earthquake.product.AbstractListener;
 import gov.usgs.util.DefaultConfigurable;
 import gov.usgs.util.ExecutorTask;
@@ -16,6 +17,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class ExecutorListenerNotifier extends DefaultConfigurable implements
@@ -204,9 +206,31 @@ public class ExecutorListenerNotifier extends DefaultConfigurable implements
 		LOGGER.info("[" + receiver.getName()
 				+ "] requeueing notification index '" + index.getName() + "'");
 		// find all existing notifications
-		Iterator<Notification> allNotifications = index.findNotifications(
-				(List<String>) null, (List<String>) null, (List<String>) null)
-				.iterator();
+		Iterator<Notification> allNotifications = null;
+
+		// for json index, push intersection into database if only one listener
+		if (index instanceof JsonNotificationIndex && gracefulListeners.size() == 1) {
+			NotificationIndex listenerIndex =
+					((DefaultNotificationListener) gracefulListeners.get(0))
+					.getNotificationIndex();
+			if (listenerIndex instanceof JsonNotificationIndex) {
+				// get intersection
+				try {
+					allNotifications =
+							((JsonNotificationIndex) index).getMissingNotifications(
+									((JsonNotificationIndex) listenerIndex).getTable()).iterator();
+				} catch (Exception e) {
+					LOGGER.log(Level.INFO, "Exception loading intersection, continuing", e);
+				}
+			}
+		}
+
+		if (allNotifications == null) {
+			// fallback to previous behavior
+			allNotifications = index.findNotifications(
+					(List<String>) null, (List<String>) null, (List<String>) null)
+					.iterator();
+		}
 		LOGGER.info("Done finding existing notifications");
 
 		// queue them for processing in case they were previous missed

--- a/src/main/java/gov/usgs/earthquake/distribution/ExecutorListenerNotifier.java
+++ b/src/main/java/gov/usgs/earthquake/distribution/ExecutorListenerNotifier.java
@@ -32,19 +32,19 @@ public class ExecutorListenerNotifier extends DefaultConfigurable implements
 	 * Notification listeners registered to receive notifications, and an
 	 * ExecutorService that delivers Notifications to each in a separate thread.
 	 */
-	private Map<NotificationListener, ExecutorService> notificationListeners = new HashMap<NotificationListener, ExecutorService>();
+	protected Map<NotificationListener, ExecutorService> notificationListeners = new HashMap<NotificationListener, ExecutorService>();
 
 	/**
 	 * Make sure listener will accept notification before queueing it for
 	 * processing.
 	 */
-	private boolean acceptBeforeQueuing = true;
+	protected boolean acceptBeforeQueuing = true;
 
 	/**
 	 * Timer used to retry tasks when they fail and listeners have configured
 	 * retryDelay.
 	 */
-	private Timer retryTimer = new Timer();
+	protected Timer retryTimer = new Timer();
 
 	public ExecutorListenerNotifier(final DefaultNotificationReceiver receiver) {
 		this.receiver = receiver;

--- a/src/main/java/gov/usgs/earthquake/distribution/FutureListenerNotifier.java
+++ b/src/main/java/gov/usgs/earthquake/distribution/FutureListenerNotifier.java
@@ -1,0 +1,82 @@
+package gov.usgs.earthquake.distribution;
+
+import gov.usgs.earthquake.product.AbstractListener;
+import gov.usgs.util.FutureExecutorTask;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.logging.Logger;
+
+/**
+ * FutureListenerNotifier is similar to ExecutorListenerNotifier, but uses
+ * Futures with an ExecutorService to implement timeouts instead of Timers.
+ *
+ * backgroundService is an unbounded executor, but will execute only as many
+ * threads are allowed by listener executors since listener executors submit
+ * tasks to the backgroundService and wait on the future.
+ *
+ * This ends up being more efficient because the threads where jobs execute are
+ * cached, instead of a new Timer thread created for each task.
+ */
+public class FutureListenerNotifier extends ExecutorListenerNotifier {
+
+  private static final Logger LOGGER = Logger
+      .getLogger(FutureListenerNotifier.class.getName());
+
+  /** Service where tasks execute using futures for timeouts. */
+  private ExecutorService backgroundService;
+
+  public FutureListenerNotifier(final DefaultNotificationReceiver receiver) {
+    super(receiver);
+  }
+
+  @Override
+  protected void queueNotification(final NotificationListener listener,
+      final NotificationEvent event) {
+    if (acceptBeforeQueuing
+        && listener instanceof DefaultNotificationListener) {
+      DefaultNotificationListener defaultListener = (DefaultNotificationListener) listener;
+      if (!defaultListener.accept(event.getNotification().getProductId())) {
+        return;
+      }
+    }
+
+    // determine retry delay
+    long retryDelay = 0L;
+    if (listener instanceof AbstractListener) {
+      retryDelay = ((AbstractListener) listener).getRetryDelay();
+    }
+
+    ExecutorService listenerExecutor = notificationListeners.get(listener);
+    FutureExecutorTask<Void> listenerTask = new FutureExecutorTask<Void>(
+        backgroundService, listenerExecutor, listener.getMaxTries(),
+        listener.getTimeout(), new NotificationListenerCallable(
+            listener, event), retryTimer, retryDelay);
+    listenerExecutor.submit(listenerTask);
+
+    // log how many notifications are pending
+    if (listenerExecutor instanceof ThreadPoolExecutor) {
+      BlockingQueue<Runnable> pending = ((ThreadPoolExecutor) listenerExecutor)
+          .getQueue();
+      LOGGER.fine("[" + event.getNotificationReceiver().getName()
+          + "] listener (" + listener.getName() + ") has "
+          + pending.size() + " queued notifications");
+    }
+  }
+
+  @Override
+  public void shutdown() throws Exception {
+    super.shutdown();
+    backgroundService.shutdown();
+    backgroundService = null;
+  }
+
+  @Override
+  public void startup() throws Exception {
+    backgroundService = Executors.newCachedThreadPool();
+    super.startup();
+  }
+
+}

--- a/src/main/java/gov/usgs/earthquake/distribution/NotificationListenerCallable.java
+++ b/src/main/java/gov/usgs/earthquake/distribution/NotificationListenerCallable.java
@@ -17,7 +17,7 @@ public class NotificationListenerCallable implements Callable<Void> {
 
 	/**
 	 * Create an ExecutorListenerNotifierCallable.
-	 * 
+	 *
 	 * @param listener
 	 *            the listener to notify
 	 * @param event
@@ -34,6 +34,7 @@ public class NotificationListenerCallable implements Callable<Void> {
 			listener.onNotification(event);
 			return null;
 		} catch (Exception e) {
+			e.printStackTrace();
 			LOGGER.log(Level.WARNING, "["
 					+ event.getNotificationReceiver().getName()
 					+ "] listener (" + listener.getName()

--- a/src/main/java/gov/usgs/earthquake/distribution/NotificationListenerCallable.java
+++ b/src/main/java/gov/usgs/earthquake/distribution/NotificationListenerCallable.java
@@ -34,7 +34,6 @@ public class NotificationListenerCallable implements Callable<Void> {
 			listener.onNotification(event);
 			return null;
 		} catch (Exception e) {
-			e.printStackTrace();
 			LOGGER.log(Level.WARNING, "["
 					+ event.getNotificationReceiver().getName()
 					+ "] listener (" + listener.getName()

--- a/src/main/java/gov/usgs/earthquake/distribution/ProductClient.java
+++ b/src/main/java/gov/usgs/earthquake/distribution/ProductClient.java
@@ -64,7 +64,7 @@ public class ProductClient extends DefaultConfigurable implements
 		ProductClientMBean, Bootstrappable {
 
 	/** The "release" version number. */
-	public static final String RELEASE_VERSION = "Version 2.6.0 2020-11-20";
+	public static final String RELEASE_VERSION = "Version 2.6.1 2020-11-30";
 
 	/** Property name used on products for current RELEASE_VERSION. */
 	public static final String PDL_CLIENT_VERSION_PROPERTY = "pdl-client-version";

--- a/src/main/java/gov/usgs/earthquake/distribution/ProductClient.java
+++ b/src/main/java/gov/usgs/earthquake/distribution/ProductClient.java
@@ -64,7 +64,7 @@ public class ProductClient extends DefaultConfigurable implements
 		ProductClientMBean, Bootstrappable {
 
 	/** The "release" version number. */
-	public static final String RELEASE_VERSION = "Version 2.7.0 2020-12-01";
+	public static final String RELEASE_VERSION = "Version 2.7.0 2020-12-03";
 
 	/** Property name used on products for current RELEASE_VERSION. */
 	public static final String PDL_CLIENT_VERSION_PROPERTY = "pdl-client-version";

--- a/src/main/java/gov/usgs/earthquake/distribution/ProductClient.java
+++ b/src/main/java/gov/usgs/earthquake/distribution/ProductClient.java
@@ -64,7 +64,7 @@ public class ProductClient extends DefaultConfigurable implements
 		ProductClientMBean, Bootstrappable {
 
 	/** The "release" version number. */
-	public static final String RELEASE_VERSION = "Version 2.6.1 2020-11-30";
+	public static final String RELEASE_VERSION = "Version 2.7.0 2020-12-01";
 
 	/** Property name used on products for current RELEASE_VERSION. */
 	public static final String PDL_CLIENT_VERSION_PROPERTY = "pdl-client-version";

--- a/src/main/java/gov/usgs/earthquake/indexer/Indexer.java
+++ b/src/main/java/gov/usgs/earthquake/indexer/Indexer.java
@@ -478,7 +478,9 @@ public class Indexer extends DefaultNotificationListener {
 	protected boolean onBeforeProcessNotification(Notification notification) throws Exception {
 		// try to short-circuit duplicates
 		if (!isProcessDuplicates() && hasProductBeenIndexed(notification.getProductId())) {
-			LOGGER.fine("[" + getName() + " notification already indexed, skipping");
+			LOGGER.finer(
+					"[" + getName() + "] notification already indexed, skipping "
+					+ notification.getProductId().toString());
 			return false;
 		}
 		// otherwise, use default behavior

--- a/src/main/java/gov/usgs/earthquake/indexer/JDBCProductIndex.java
+++ b/src/main/java/gov/usgs/earthquake/indexer/JDBCProductIndex.java
@@ -404,6 +404,21 @@ public class JDBCProductIndex extends JDBCConnection implements ProductIndex {
 	@Override
 	public synchronized List<ProductSummary> getProducts(ProductIndexQuery query)
 			throws Exception {
+		// load full product summaries by default
+		return getProducts(query, true);
+	}
+
+	/**
+	 * Load product summaries.
+	 *
+	 * @param query
+	 *     product query
+	 * @param loadDetails
+	 *     whether to call {@link #loadProductSummaries(List)},
+	 *     which loads links and properties with additional queries.
+	 */
+	public synchronized List<ProductSummary> getProducts(ProductIndexQuery query, final boolean loadDetails)
+			throws Exception {
 		final List<String> clauseList = buildProductClauses(query);
 		final String sql = buildProductQuery(clauseList);
 
@@ -418,8 +433,10 @@ public class JDBCProductIndex extends JDBCConnection implements ProductIndex {
 			}
 		}
 
-		// load properties and links
-		loadProductSummaries(products);
+		if (loadDetails) {
+			// load properties and links
+			loadProductSummaries(products);
+		}
 
 		return products;
 	}

--- a/src/main/java/gov/usgs/util/DirectoryPoller.java
+++ b/src/main/java/gov/usgs/util/DirectoryPoller.java
@@ -16,14 +16,14 @@ import java.util.TimerTask;
 
 /**
  * Monitor a directory for files, notifying FileListenerInterfaces.
- * 
+ *
  * Implementers of the FileListenerInterface should process files before
  * returning, because these files may move or disappear.
  */
 public class DirectoryPoller {
 
 	/** Timer schedules polling frequency. */
-	private Timer timer = new Timer();
+	private Timer timer;
 
 	/** Directory to watch. */
 	private final File pollDirectory;
@@ -36,7 +36,7 @@ public class DirectoryPoller {
 
 	/**
 	 * Create a DirectoryPoller.
-	 * 
+	 *
 	 * @param pollDirectory
 	 *            directory that is polled for new files.
 	 * @param storageDirectory
@@ -73,11 +73,11 @@ public class DirectoryPoller {
 
 	/**
 	 * Start polling in a background thread.
-	 * 
+	 *
 	 * Any previously scheduled polling is stopped before starting at this
 	 * frequency. This schedules using fixed-delay (time between complete polls)
 	 * as opposed to fixed-rate (how often to start polling).
-	 * 
+	 *
 	 * @param frequencyInMilliseconds
 	 *            how often to poll.
 	 */
@@ -104,9 +104,9 @@ public class DirectoryPoller {
 	/**
 	 * The Polling Task. Notifies all listeners then either deletes or moves the
 	 * file to storage.
-	 * 
+	 *
 	 * @author jmfee
-	 * 
+	 *
 	 */
 	protected class PollTask extends TimerTask {
 		public void run() {
@@ -123,7 +123,7 @@ public class DirectoryPoller {
 
 	/**
 	 * Notify all listeners that files exist and need to be processed.
-	 * 
+	 *
 	 * @param file
 	 */
 	public void notifyListeners(final File file) {
@@ -142,7 +142,7 @@ public class DirectoryPoller {
 	 * Move a file from polldir to storage directory. Attempts to move file into
 	 * storage directory. The file is not moved if no storage directory was
 	 * specified, or if the file no longer exists.
-	 * 
+	 *
 	 * @param file
 	 *            file to move.
 	 */

--- a/src/main/java/gov/usgs/util/ExecutorTask.java
+++ b/src/main/java/gov/usgs/util/ExecutorTask.java
@@ -1,6 +1,6 @@
 /*
  * ExecutorTask
- * 
+ *
  * $Id$
  * $URL$
  */
@@ -21,13 +21,13 @@ import java.util.logging.Logger;
 
 /**
  * A wrapper for Runnable or Callable objects for use with an ExecutorService.
- * 
+ *
  * Can be used to schedule interrupt based timeouts, multiple attempts, and
  * Future style exception tracking for Runnable or Callable objects.
- * 
+ *
  * @param <T> return type for callable.
  */
-public final class ExecutorTask<T> implements Future<T>, Runnable {
+public class ExecutorTask<T> implements Future<T>, Runnable {
 
 	/** Logging object. */
 	private static final Logger LOGGER = Logger.getLogger(ExecutorTask.class
@@ -43,49 +43,49 @@ public final class ExecutorTask<T> implements Future<T>, Runnable {
 	public static final long DEFAULT_TIMEOUT = 0L;
 
 	/** ExecutorService used to execute this task. */
-	private ExecutorService service;
+	protected ExecutorService service;
 
 	/** The callable to be called. */
-	private Callable<T> callable;
+	protected Callable<T> callable;
 
 	/** Timeout for task. */
-	private long timeout = DEFAULT_TIMEOUT;
+	protected long timeout = DEFAULT_TIMEOUT;
 
 	/** Number of tries to execute this task. */
-	private int maxTries = DEFAULT_NUM_TRIES;
+	protected int maxTries = DEFAULT_NUM_TRIES;
 
 	/** Number of milliseconds to wait before trying again. */
-	private long retryDelay = DEFAULT_RETRY_DELAY;
+	protected long retryDelay = DEFAULT_RETRY_DELAY;
 
 	/** Timer used to schedule retries, when they have a non-zero delay. */
-	private Timer retryTimer;
+	protected Timer retryTimer;
 
 	/** The future from the executor service. */
-	private T result;
+	protected T result;
 
 	/** List of exceptions thrown, up to maxTries in length. */
 	ArrayList<Exception> exceptions;
 
 	/** Whether this task is complete. */
-	private Boolean done = false;
+	protected Boolean done = false;
 
 	/** Whether this task has been canceled. */
-	private Boolean cancelled = false;
+	protected Boolean cancelled = false;
 
 	/** Number of tries used. */
-	private int numTries = 0;
+	protected int numTries = 0;
 
 	/** The thread where this is running, used to interrupt. */
-	private Thread runThread = null;
+	protected Thread runThread = null;
 
 	/** Name for this task. */
-	private String name = null;
+	protected String name = null;
 
-	private final Object syncObject = new Object();
+	protected final Object syncObject = new Object();
 
 	/**
 	 * Construct a new ExecutorTask
-	 * 
+	 *
 	 * @param service
 	 *            ExecutorService that this task will be submitted to.
 	 * @param maxTries
@@ -106,7 +106,7 @@ public final class ExecutorTask<T> implements Future<T>, Runnable {
 
 	/**
 	 * Wraps a runnable and result using the CallableRunnable class.
-	 * 
+	 *
 	 * @see java.util.concurrent.Executors#callable(Runnable, Object)
 	 */
 	public ExecutorTask(ExecutorService service, int maxTries, long timeout,
@@ -116,7 +116,7 @@ public final class ExecutorTask<T> implements Future<T>, Runnable {
 
 	/**
 	 * Construct a new ExecutorTask
-	 * 
+	 *
 	 * @param service
 	 *            ExecutorService that this task will be submitted to.
 	 * @param maxTries
@@ -223,7 +223,7 @@ public final class ExecutorTask<T> implements Future<T>, Runnable {
 	 * Called when task is completed, either successfully, or unsuccessfully and
 	 * has no more tries
 	 */
-	private void done() {
+	protected void done() {
 		// done running, either successfully or because out of tries
 		done = true;
 		// notify anyone waiting for task to complete
@@ -308,7 +308,7 @@ public final class ExecutorTask<T> implements Future<T>, Runnable {
 
 	/**
 	 * Number of tries used.
-	 * 
+	 *
 	 * @return actual number of attempts.
 	 */
 	public int getNumTries() {
@@ -317,7 +317,7 @@ public final class ExecutorTask<T> implements Future<T>, Runnable {
 
 	/**
 	 * Maximum number of tries before giving up.
-	 * 
+	 *
 	 * @return maximum number of attempts.
 	 */
 	public int getMaxTries() {
@@ -326,7 +326,7 @@ public final class ExecutorTask<T> implements Future<T>, Runnable {
 
 	/**
 	 * Any exceptions thrown, during any execution attempt.
-	 * 
+	 *
 	 * @return array of thrown exceptions. should contain no more than numTries
 	 *         exceptions.
 	 */
@@ -336,7 +336,7 @@ public final class ExecutorTask<T> implements Future<T>, Runnable {
 
 	/**
 	 * The callable object that is/was called.
-	 * 
+	 *
 	 * @return The callable object for this task. If this task was created using
 	 *         a runnable, this was created using Executors.callable(Runnable).
 	 */
@@ -384,7 +384,7 @@ public final class ExecutorTask<T> implements Future<T>, Runnable {
 
 	/**
 	 * Submit an ExecutorTask to an ExecutorService.
-	 * 
+	 *
 	 * Used to defer resubmission of a task after it fails, but scheduling its
 	 * resubmission using a timer.
 	 */
@@ -395,7 +395,7 @@ public final class ExecutorTask<T> implements Future<T>, Runnable {
 
 		/**
 		 * Construct a new SubmitTaskToExecutor instance.
-		 * 
+		 *
 		 * @param task
 		 *            the task to resubmit.
 		 */

--- a/src/main/java/gov/usgs/util/ExecutorTask.java
+++ b/src/main/java/gov/usgs/util/ExecutorTask.java
@@ -187,7 +187,7 @@ public class ExecutorTask<T> implements Future<T>, Runnable {
 			runThread = null;
 
 			// computed without exceptions, done
-			done();
+			setDone();
 			// }
 		} catch (Exception e) {
 			LOGGER.log(Level.INFO, "Exception executing task", e);
@@ -210,7 +210,7 @@ public class ExecutorTask<T> implements Future<T>, Runnable {
 				}
 			} else {
 				// cancelled or out of tries, done
-				done();
+				setDone();
 			}
 			// }
 		} finally {
@@ -223,7 +223,7 @@ public class ExecutorTask<T> implements Future<T>, Runnable {
 	 * Called when task is completed, either successfully, or unsuccessfully and
 	 * has no more tries
 	 */
-	protected void done() {
+	protected void setDone() {
 		// done running, either successfully or because out of tries
 		done = true;
 		// notify anyone waiting for task to complete
@@ -247,7 +247,7 @@ public class ExecutorTask<T> implements Future<T>, Runnable {
 
 		// thread may still be running, if it doesn't handle interrupts well,
 		// but Future interface says we are done
-		done();
+		setDone();
 
 		return cancelled;
 	}

--- a/src/main/java/gov/usgs/util/FutureExecutorTask.java
+++ b/src/main/java/gov/usgs/util/FutureExecutorTask.java
@@ -130,7 +130,7 @@ public class FutureExecutorTask<T> extends ExecutorTask<T> {
       runThread = null;
 
       // computed without exceptions, done
-      done();
+      setDone();
     } catch (Exception e) {
       if (e instanceof ExecutionException) {
         // unpack cause
@@ -158,7 +158,7 @@ public class FutureExecutorTask<T> extends ExecutorTask<T> {
         }
       } else {
         // cancelled or out of tries, done
-        done();
+        setDone();
       }
     }
   }

--- a/src/main/java/gov/usgs/util/FutureExecutorTask.java
+++ b/src/main/java/gov/usgs/util/FutureExecutorTask.java
@@ -136,7 +136,7 @@ public class FutureExecutorTask<T> extends ExecutorTask<T> {
         // unpack cause
         Throwable cause = e.getCause();
         if (cause != null && cause instanceof Exception) {
-          e = (Exception) e.getCause();
+          e = (Exception) cause;
         }
       }
       LOGGER.log(Level.INFO, "Exception executing task", e);

--- a/src/main/java/gov/usgs/util/FutureExecutorTask.java
+++ b/src/main/java/gov/usgs/util/FutureExecutorTask.java
@@ -119,8 +119,8 @@ public class FutureExecutorTask<T> extends ExecutorTask<T> {
         } else {
           result = future.get();
         }
-      } catch (InterruptedException e) {
-        // interrupt the future too
+      } finally {
+        // cancel whether successful (noop) or exception (interrupt callable)
         future.cancel(true);
       }
 

--- a/src/main/java/gov/usgs/util/FutureExecutorTask.java
+++ b/src/main/java/gov/usgs/util/FutureExecutorTask.java
@@ -1,0 +1,187 @@
+package gov.usgs.util;
+
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * FutureExecutorTask overrides how timeouts are handled to use a
+ * separate executor service with Futures.
+ */
+public class FutureExecutorTask<T> extends ExecutorTask<T> {
+
+  /** Logging object. */
+  private static final Logger LOGGER = Logger.getLogger(FutureExecutorTask.class
+      .getName());
+
+  /** Default number of milliseconds to wait before a retry. */
+  public static final long DEFAULT_RETRY_DELAY = 0L;
+
+  /** Default number of tries to run this task. */
+  public static final int DEFAULT_NUM_TRIES = 1;
+
+  /** Default timeout for this task. */
+  public static final long DEFAULT_TIMEOUT = 0L;
+
+  /** ExecutorService used to execute callable. */
+  protected ExecutorService backgroundService;
+
+  /**
+   * Construct a new ExecutorTask
+   *
+   * @param service
+   *            ExecutorService that this task will be submitted to.
+   * @param maxTries
+   *            maximum number of tries callable can throw an exception or
+   *            timeout before giving up. &lt; 1 means never run.
+   * @param timeout
+   *            number of milliseconds to allow callable to run before it is
+   *            interrupted. &lt;= 0 means never timeout.
+   * @param callable
+   *            the callable to call. To work well, the callable should handle
+   *            interrupts gracefully.
+   * @see InterruptedException
+   */
+  public FutureExecutorTask(ExecutorService backgroundService, ExecutorService service,
+      int maxTries, long timeout, Callable<T> callable) {
+    super(service, maxTries, timeout, callable, null, DEFAULT_RETRY_DELAY);
+    this.backgroundService = backgroundService;
+  }
+
+  /**
+   * Wraps a runnable and result using the CallableRunnable class.
+   *
+   * @see java.util.concurrent.Executors#callable(Runnable, Object)
+   */
+  public FutureExecutorTask(ExecutorService backgroundService, ExecutorService service,
+      int maxTries, long timeout, Runnable runnable, T result) {
+    super(service, maxTries, timeout, Executors.callable(runnable, result));
+    this.backgroundService = backgroundService;
+  }
+
+  /**
+   * Construct a new FutureExecutorTask
+   *
+   * @param service
+   *            ExecutorService that this task will be submitted to.
+   * @param maxTries
+   *            maximum number of tries callable can throw an exception or
+   *            timeout before giving up. &lt; 1 means never run.
+   * @param timeout
+   *            number of milliseconds to allow callable to run before it is
+   *            interrupted. &lt;= 0 means never timeout.
+   * @param callable
+   *            the callable to call. To work well, the callable should handle
+   *            interrupts gracefully.
+   * @param retryTimer
+   *            a timer used to schedule retries when retryDelay is non-zero.
+   * @param retryDelay
+   *            the number of milliseconds to wait before retrying after an
+   *            exception.
+   * @see InterruptedException
+   */
+  public FutureExecutorTask(ExecutorService backgroundService, ExecutorService service,
+      int maxTries, long timeout, Callable<T> callable, Timer retryTimer,
+      long retryDelay) {
+    super(service, maxTries, timeout, callable, retryTimer, retryDelay);
+    this.backgroundService = backgroundService;
+  }
+
+  /**
+   * Run calls the callable, scheduling timeout interruption, catching
+   * exceptions, and potentially resubmitting to the executor service.
+   */
+  @Override
+  public void run() {
+    try {
+      if (done || cancelled || numTries >= maxTries) {
+        // already done, cancelled, or out of attempts
+        return;
+      }
+
+      // otherwise,
+      ++numTries;
+
+      // signal that we are running
+      runThread = Thread.currentThread();
+
+      // use future to manage timeout
+      Future<T> future = backgroundService.submit(this.callable);
+      try {
+        if (timeout > 0) {
+          result = future.get(timeout, TimeUnit.MILLISECONDS);
+        } else {
+          result = future.get();
+        }
+      } catch (InterruptedException e) {
+        // interrupt the future too
+        future.cancel(true);
+      }
+
+      // signal that we are done running
+      runThread = null;
+
+      // computed without exceptions, done
+      done();
+    } catch (Exception e) {
+      LOGGER.log(Level.INFO, "Exception executing task", e);
+      // signal that we are not running
+      runThread = null;
+
+      // track this exception
+      exceptions.add(e);
+
+      // try to resubmit
+      if (!cancelled && numTries < maxTries) {
+        LOGGER.info("Resubmitting task to executor " + numTries + "/"
+            + maxTries + " attempts");
+        SubmitTaskToExecutor retryTask = new SubmitTaskToExecutor(this);
+        if (retryDelay <= 0L || retryTimer == null) {
+          retryTask.run();
+        } else {
+          retryTimer.schedule(retryTask, retryDelay);
+        }
+      } else {
+        // cancelled or out of tries, done
+        done();
+      }
+    }
+  }
+
+  /**
+   * Submit a FutureExecutorTask to an ExecutorService.
+   *
+   * Used to defer resubmission of a task after it fails, but scheduling its
+   * resubmission using a timer.
+   */
+  private class SubmitTaskToExecutor extends TimerTask {
+
+    /** The task to resubmit. */
+    private FutureExecutorTask<T> task;
+
+    /**
+     * Construct a new SubmitTaskToExecutor instance.
+     *
+     * @param task
+     *            the task to resubmit.
+     */
+    public SubmitTaskToExecutor(final FutureExecutorTask<T> task) {
+      this.task = task;
+    }
+
+    /**
+     * Submits the task to the executor.
+     */
+    public void run() {
+      service.submit(task);
+    }
+
+  }
+
+}

--- a/src/main/java/gov/usgs/util/StreamUtils.java
+++ b/src/main/java/gov/usgs/util/StreamUtils.java
@@ -31,7 +31,7 @@ public class StreamUtils {
 	public static final int DEFAULT_BUFFER_SIZE = 4096;
 
 	/** Default connect timeout for url connections. */
-	public static final int DEFAULT_URL_CONNECT_TIMEOUT = 15000;
+	public static final int DEFAULT_URL_CONNECT_TIMEOUT = 5000;
 
 	/** Default read timeout for url connections. */
 	public static final int DEFAULT_URL_READ_TIMEOUT = 15000;

--- a/src/main/java/gov/usgs/util/TimeoutProcess.java
+++ b/src/main/java/gov/usgs/util/TimeoutProcess.java
@@ -1,6 +1,6 @@
 /*
  * TimeoutProcess
- * 
+ *
  * $Id$
  * $URL$
  */
@@ -13,10 +13,10 @@ import java.util.Timer;
 
 /**
  * TimeoutProcess wraps a Process object.
- * 
+ *
  * It is most commonly used with TimeoutProcessBuilder, which configures the
  * process timeout (and sets the timed out state once the timeout is reached).
- * 
+ *
  * @see java.lang.Process
  * @see TimeoutProcessBuilder
  * @see ProcessTimeoutException
@@ -37,7 +37,7 @@ public class TimeoutProcess {
 
 	/**
 	 * Construct a new TimeoutProcess.
-	 * 
+	 *
 	 * @param process
 	 *            the wrapped process.
 	 */
@@ -72,22 +72,25 @@ public class TimeoutProcess {
 	/**
 	 * Wait for the process to complete, either normally or because its timeout
 	 * was reached.
-	 * 
+	 *
 	 * @return exitStatus.
 	 * @throws InterruptedException
 	 * @throws ProcessTimeoutException
 	 *             if the process timed out before exiting.
 	 */
 	public int waitFor() throws InterruptedException, IOException, ProcessTimeoutException {
-		int status = process.waitFor();
+		int status = -1;
+		try {
+			status = process.waitFor();
 
-		if (timeoutElapsed()) {
-			throw new ProcessTimeoutException("The process has timed out.");
-		}
-
-		if (timer != null) {
-			// the timer hasn't destroyed this process already, cancel it.
-			timer.cancel();
+			if (timeoutElapsed()) {
+				throw new ProcessTimeoutException("The process has timed out.");
+			}
+		} finally {
+			if (timer != null) {
+				// the timer hasn't destroyed this process already, cancel it.
+				timer.cancel();
+			}
 		}
 
 		try {


### PR DESCRIPTION
- Add connect/read timeouts for HTTPURLConnections, based on observed hanging threads:

```
"pool-1-thread-1" #15 prio=5 os_prio=0 cpu=857030.81ms elapsed=284571.09s tid=0x00007f92e049a000 nid=0x4f80 runnable  [0x00007f92b446b000]
   java.lang.Thread.State: RUNNABLE
        at java.net.SocketInputStream.socketRead0(java.base@11.0.9.1/Native Method)
        at java.net.SocketInputStream.socketRead(java.base@11.0.9.1/SocketInputStream.java:115)
        at java.net.SocketInputStream.read(java.base@11.0.9.1/SocketInputStream.java:168)
        at java.net.SocketInputStream.read(java.base@11.0.9.1/SocketInputStream.java:140)
        at sun.security.ssl.SSLSocketInputRecord.read(java.base@11.0.9.1/SSLSocketInputRecord.java:476)
        at sun.security.ssl.SSLSocketInputRecord.readHeader(java.base@11.0.9.1/SSLSocketInputRecord.java:470)
        at sun.security.ssl.SSLSocketInputRecord.bytesInCompletePacket(java.base@11.0.9.1/SSLSocketInputRecord.java:70)
        at sun.security.ssl.SSLSocketImpl.readApplicationRecord(java.base@11.0.9.1/SSLSocketImpl.java:1354)
        at sun.security.ssl.SSLSocketImpl$AppInputStream.read(java.base@11.0.9.1/SSLSocketImpl.java:963)
        at java.io.BufferedInputStream.fill(java.base@11.0.9.1/BufferedInputStream.java:252)
        at java.io.BufferedInputStream.read1(java.base@11.0.9.1/BufferedInputStream.java:292)
        at java.io.BufferedInputStream.read(java.base@11.0.9.1/BufferedInputStream.java:351)
        - locked <0x00000000c444a9c8> (a java.io.BufferedInputStream)
        at sun.net.www.http.HttpClient.parseHTTPHeader(java.base@11.0.9.1/HttpClient.java:754)
        at sun.net.www.http.HttpClient.parseHTTP(java.base@11.0.9.1/HttpClient.java:689)
        at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(java.base@11.0.9.1/HttpURLConnection.java:1615)
        - locked <0x00000000c444aa20> (a sun.net.www.protocol.https.DelegateHttpsURLConnection)
        at sun.net.www.protocol.http.HttpURLConnection.getInputStream(java.base@11.0.9.1/HttpURLConnection.java:1520)
        - locked <0x00000000c444aa20> (a sun.net.www.protocol.https.DelegateHttpsURLConnection)
        at sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(java.base@11.0.9.1/HttpsURLConnectionImpl.java:250)
        - locked <0x00000000c444ab90> (a sun.net.www.protocol.https.HttpsURLConnectionImpl)
        at gov.usgs.earthquake.aws.HttpResponse.<init>(HttpResponse.java:28)
        at gov.usgs.earthquake.aws.AwsProductSender.postProductJson(AwsProductSender.java:195)
        at gov.usgs.earthquake.aws.AwsProductSender.getUploadUrls(AwsProductSender.java:154)
        at gov.usgs.earthquake.aws.AwsProductSender.sendProduct(AwsProductSender.java:113)
        at gov.usgs.earthquake.distribution.RelayProductListener.onProduct(RelayProductListener.java:54)
        at gov.usgs.earthquake.distribution.DefaultNotificationListener.onNotification(DefaultNotificationListener.java:130)
        at gov.usgs.earthquake.distribution.NotificationListenerCallable.call(NotificationListenerCallable.java:34)
        at gov.usgs.earthquake.distribution.NotificationListenerCallable.call(NotificationListenerCallable.java:10)
        at gov.usgs.util.ExecutorTask.run(ExecutorTask.java:183)
        at java.util.concurrent.Executors$RunnableAdapter.call(java.base@11.0.9.1/Executors.java:515)
        at java.util.concurrent.FutureTask.run(java.base@11.0.9.1/FutureTask.java:264)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.9.1/ThreadPoolExecutor.java:1128)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.9.1/ThreadPoolExecutor.java:628)
        at java.lang.Thread.run(java.base@11.0.9.1/Thread.java:829)
```

- cancel Timers, and use Futures for timeouts to reduce thread creation.  Many references showed up in heap dump.